### PR TITLE
013 hot fix/update api for tech report

### DIFF
--- a/cpp/infernux/function/renderer/InxRenderer.cpp
+++ b/cpp/infernux/function/renderer/InxRenderer.cpp
@@ -1292,6 +1292,13 @@ void InxRenderer::UnregisterGUIRenderable(const char *name)
     }
 }
 
+void InxRenderer::SetGUIPlayerMode(bool enabled)
+{
+    if (m_gui) {
+        m_gui->SetPlayerMode(enabled);
+    }
+}
+
 void InxRenderer::QueueDockTabSelection(const char *windowId)
 {
     if (m_gui) {

--- a/cpp/infernux/function/renderer/InxRenderer.h
+++ b/cpp/infernux/function/renderer/InxRenderer.h
@@ -98,6 +98,7 @@ class InxRenderer
     void RegisterGUIRenderable(const char *name, std::shared_ptr<InxGUIRenderable> renderable);
     void UnregisterGUIRenderable(const char *name);
     void QueueDockTabSelection(const char *windowId);
+    void SetGUIPlayerMode(bool enabled);
 
     // ImGui texture management
     uint64_t UploadTextureForImGui(const std::string &name, const unsigned char *pixels, int width, int height);

--- a/cpp/infernux/function/renderer/InxVkCoreModular.cpp
+++ b/cpp/infernux/function/renderer/InxVkCoreModular.cpp
@@ -53,6 +53,12 @@ void DestroyLingeringMaterialPassPipelines(VkDevice device)
 
         for (int passIndex = 0; passIndex < static_cast<int>(ShaderCompileTarget::Count); ++passIndex) {
             const auto pass = static_cast<ShaderCompileTarget>(passIndex);
+            // Shadow pipelines are owned by m_shadowPipelineCache and
+            // destroyed in CleanupShadowPipeline() — skip here.
+            if (pass == ShaderCompileTarget::Shadow) {
+                material->ClearPassPipeline(pass);
+                continue;
+            }
             const VkPipeline pipeline = material->GetPassPipeline(pass);
             if (pipeline != VK_NULL_HANDLE) {
                 if (destroyedPipelines.insert(pipeline).second) {
@@ -338,6 +344,20 @@ void InxVkCoreModular::InvalidateShaderCache(const std::string &shaderId)
     // Invalidate all materials using this shader in MaterialPipelineManager
     if (m_materialPipelineManagerInitialized) {
         m_materialPipelineManager.InvalidateMaterialsUsingShader(shaderId);
+    }
+
+    // Invalidate cached shadow pipelines that reference this shader
+    {
+        VkDevice dev = GetDevice();
+        for (auto it = m_shadowPipelineCache.begin(); it != m_shadowPipelineCache.end();) {
+            if (it->first.find(shaderId) != std::string::npos) {
+                if (it->second != VK_NULL_HANDLE)
+                    vkDestroyPipeline(dev, it->second, nullptr);
+                it = m_shadowPipelineCache.erase(it);
+            } else {
+                ++it;
+            }
+        }
     }
 
     // Also unload the shader module so it gets recreated

--- a/cpp/infernux/function/renderer/InxVkCoreModular.h
+++ b/cpp/infernux/function/renderer/InxVkCoreModular.h
@@ -320,6 +320,23 @@ class InxVkCoreModular
         ++m_ensureFrameCounter;
     }
 
+    /// @brief Bulk-stamp all per-object buffer entries with the current frame
+    /// counter without hash-map lookups.  Use when no `forceBufferUpdate` is
+    /// set and no new objects appeared, skipping the full EnsureObjectBuffers
+    /// loop (~0.3 ms saved at 10 k objects).
+    void BulkStampEnsuredFrame()
+    {
+        for (auto &[id, entry] : m_perObjectBuffers) {
+            entry.ensuredOnFrame = m_ensureFrameCounter;
+        }
+    }
+
+    /// @brief Return the count of per-object buffer entries.
+    size_t GetPerObjectBufferCount() const
+    {
+        return m_perObjectBuffers.size();
+    }
+
     /// @brief Remove per-object buffers for objects that are no longer active.
     /// Call once per frame after SetDrawCalls with the current active draw calls.
     void CleanupUnusedBuffers(const std::vector<DrawCall> &activeDrawCalls);
@@ -999,6 +1016,10 @@ class InxVkCoreModular
     VkSampler m_shadowDepthSampler = VK_NULL_HANDLE;
     VkRenderPass m_shadowCompatRenderPass = VK_NULL_HANDLE; ///< For pipeline compatibility
     bool m_shadowPipelineReady = false;
+
+    /// Cache of shadow pipelines keyed by shader ID (vert|frag).
+    /// Materials sharing the same shader share the same shadow VkPipeline.
+    std::unordered_map<std::string, VkPipeline> m_shadowPipelineCache;
 
     /// @brief Lazily create/recreate shadow pipeline resources.
     bool EnsureShadowPipeline(VkRenderPass compatibleRenderPass);

--- a/cpp/infernux/function/renderer/MaterialPipelineManager.cpp
+++ b/cpp/infernux/function/renderer/MaterialPipelineManager.cpp
@@ -120,6 +120,14 @@ void MaterialPipelineManager::DestroyNonForwardPipelines(InxMaterial *material)
 {
     for (int i = 1; i < static_cast<int>(ShaderCompileTarget::Count); ++i) {
         const auto pass = static_cast<ShaderCompileTarget>(i);
+        // Shadow pipelines are owned by the shadow pipeline cache in
+        // InxVkCoreModular — only clear the material's reference here.
+        if (pass == ShaderCompileTarget::Shadow) {
+            material->SetPassPipeline(pass, VK_NULL_HANDLE);
+            material->SetPassPipelineLayout(pass, VK_NULL_HANDLE);
+            material->SetPassShaderProgram(pass, nullptr);
+            continue;
+        }
         VkPipeline pp = material->GetPassPipeline(pass);
         if (pp != VK_NULL_HANDLE) {
             vkDestroyPipeline(m_device, pp, nullptr);

--- a/cpp/infernux/function/renderer/VkCoreDraw.cpp
+++ b/cpp/infernux/function/renderer/VkCoreDraw.cpp
@@ -369,10 +369,28 @@ void InxVkCoreModular::DrawSceneFiltered(VkCommandBuffer cmdBuf, uint32_t width,
     }
 
     // ---- Sort if requested (skip for 0-1 elements) ----
+    // Uniform-batch fast path: when every eligible entry shares the same
+    // material hash and vertex buffer, all entries will be emitted as a
+    // single instanced draw regardless of ordering.  Sorting would only
+    // permute elements within that single batch, so we skip it entirely.
+    bool uniformBatch = false;
+    if (m_eligibleScratch.size() > 1) {
+        const size_t firstMatHash = m_eligibleScratch[0].materialHash;
+        const VkBuffer firstVB = m_eligibleScratch[0].vertexBuf;
+        uniformBatch = true;
+        for (size_t i = 1; i < m_eligibleScratch.size(); ++i) {
+            if (m_eligibleScratch[i].materialHash != firstMatHash ||
+                m_eligibleScratch[i].vertexBuf != firstVB) {
+                uniformBatch = false;
+                break;
+            }
+        }
+    }
+
     // is_sorted() early-out: O(N) comparison-only scan avoids the O(N log N)
     // std::sort when the eligible scratch is already in correct order from
     // a previous frame (common in stable scenes with static camera).
-    if (m_eligibleScratch.size() > 1) {
+    if (m_eligibleScratch.size() > 1 && !uniformBatch) {
         // In left-handed view space: near objects have small positive Z, far
         // objects have larger positive Z.
         if (sortMode == "front_to_back") {

--- a/cpp/infernux/function/renderer/VkCoreDraw.cpp
+++ b/cpp/infernux/function/renderer/VkCoreDraw.cpp
@@ -308,9 +308,15 @@ void InxVkCoreModular::DrawSceneFiltered(VkCommandBuffer cmdBuf, uint32_t width,
                 continue;
         }
 
-        // Compute view-space depth for sorting.
-        glm::vec4 viewPos = m_stagedUBO.view * glm::vec4(glm::vec3(dc.worldMatrix[3]), 1.0f);
-        float sortKey = viewPos.z;
+        // Compute view-space depth for transparent sort only.
+        // Opaque front_to_back groups by material hash + vertex buffer
+        // (stable order), so depth sort is unnecessary and its O(N log N)
+        // cost every frame is avoided via the is_sorted() early-out.
+        float sortKey = 0.0f;
+        if (sortMode == "back_to_front") {
+            glm::vec4 viewPos = m_stagedUBO.view * glm::vec4(glm::vec3(dc.worldMatrix[3]), 1.0f);
+            sortKey = viewPos.z;
+        }
 
         // Material + mesh hash for grouping optimization
         size_t matHash = std::hash<void *>{}(static_cast<void *>(material));
@@ -379,8 +385,7 @@ void InxVkCoreModular::DrawSceneFiltered(VkCommandBuffer cmdBuf, uint32_t width,
         const VkBuffer firstVB = m_eligibleScratch[0].vertexBuf;
         uniformBatch = true;
         for (size_t i = 1; i < m_eligibleScratch.size(); ++i) {
-            if (m_eligibleScratch[i].materialHash != firstMatHash ||
-                m_eligibleScratch[i].vertexBuf != firstVB) {
+            if (m_eligibleScratch[i].materialHash != firstMatHash || m_eligibleScratch[i].vertexBuf != firstVB) {
                 uniformBatch = false;
                 break;
             }
@@ -394,12 +399,13 @@ void InxVkCoreModular::DrawSceneFiltered(VkCommandBuffer cmdBuf, uint32_t width,
         // In left-handed view space: near objects have small positive Z, far
         // objects have larger positive Z.
         if (sortMode == "front_to_back") {
+            // Group by material + vertex buffer only (no depth).
+            // This order is stable across frames for static material assignments,
+            // so is_sorted() returns true and std::sort is skipped entirely.
             auto cmp = [](const SortableDrawCall &a, const SortableDrawCall &b) {
                 if (a.materialHash != b.materialHash)
                     return a.materialHash < b.materialHash;
-                if (a.vertexBuf != b.vertexBuf)
-                    return a.vertexBuf < b.vertexBuf;
-                return a.sortKey < b.sortKey;
+                return a.vertexBuf < b.vertexBuf;
             };
             if (!std::is_sorted(m_eligibleScratch.begin(), m_eligibleScratch.end(), cmp)) {
                 std::sort(m_eligibleScratch.begin(), m_eligibleScratch.end(), cmp);
@@ -1254,6 +1260,12 @@ void InxVkCoreModular::CleanupShadowPipeline()
         vkDestroyRenderPass(device, m_shadowCompatRenderPass, nullptr);
         m_shadowCompatRenderPass = VK_NULL_HANDLE;
     }
+    // Destroy cached shadow pipelines
+    for (auto &[key, pipeline] : m_shadowPipelineCache) {
+        if (pipeline != VK_NULL_HANDLE)
+            vkDestroyPipeline(device, pipeline, nullptr);
+    }
+    m_shadowPipelineCache.clear();
     m_shadowPipelineReady = false;
 }
 

--- a/cpp/infernux/function/renderer/VkCoreMaterial.cpp
+++ b/cpp/infernux/function/renderer/VkCoreMaterial.cpp
@@ -28,6 +28,7 @@
 #include <cctype>
 #include <filesystem>
 #include <glm/glm.hpp>
+#include <unordered_set>
 
 #include <cstring>
 
@@ -531,13 +532,9 @@ bool InxVkCoreModular::RefreshMaterialPipeline(std::shared_ptr<InxMaterial> mate
             std::string shadowFragName = fragShaderName + "/shadow";
             bool hasShadowFrag = (GetShaderModule(shadowFragName, "fragment") != VK_NULL_HANDLE);
             if (hasShadowFrag) {
-                VkPipeline oldShadow = material->GetPassPipeline(ShaderCompileTarget::Shadow);
-                if (oldShadow != VK_NULL_HANDLE) {
-                    VkDevice dev = GetDevice();
-                    m_deletionQueue.Push([dev, oldShadow]() { vkDestroyPipeline(dev, oldShadow, nullptr); });
-                    material->SetPassPipeline(ShaderCompileTarget::Shadow, VK_NULL_HANDLE);
-                }
-
+                // Shadow pipelines are owned by m_shadowPipelineCache — do NOT
+                // push the old handle to the deletion queue (it is shared).
+                material->SetPassPipeline(ShaderCompileTarget::Shadow, VK_NULL_HANDLE);
                 CreateMaterialShadowPipeline(material, vertShaderName, fragShaderName);
             }
         }
@@ -886,10 +883,10 @@ void InxVkCoreModular::CreateMaterialShadowPipeline(std::shared_ptr<InxMaterial>
     // generated shadow variant exists for this material.
     VkShaderModule fragModule = GetShaderModule(shadowFragName, "fragment");
     if (fragModule == VK_NULL_HANDLE) {
-        static int s_missingShadowFragWarnCount = 0;
-        if (s_missingShadowFragWarnCount++ < 16) {
+        static std::unordered_set<std::string> s_warnedShadowFragShaders;
+        if (s_warnedShadowFragShaders.insert(shadowFragName).second) {
             INXLOG_WARN("CreateMaterialShadowPipeline: missing shadow fragment module '", shadowFragName,
-                        "' for material '", material->GetName(), "'");
+                        "' — materials using this shader will use default shadow pass");
         }
         return;
     }
@@ -900,6 +897,14 @@ void InxVkCoreModular::CreateMaterialShadowPipeline(std::shared_ptr<InxMaterial>
             INXLOG_WARN("CreateMaterialShadowPipeline: shader modules unavailable for material '", material->GetName(),
                         "' (vert='", shadowVertName, "' fallback='", vertShaderName, "', frag='", shadowFragName, "')");
         }
+        return;
+    }
+
+    // ---- Shadow pipeline cache: share VkPipeline across materials with same shader ----
+    std::string shadowShaderKey = shadowVertName + "|" + shadowFragName;
+    auto cacheIt = m_shadowPipelineCache.find(shadowShaderKey);
+    if (cacheIt != m_shadowPipelineCache.end()) {
+        material->SetPassPipeline(ShaderCompileTarget::Shadow, cacheIt->second);
         return;
     }
 
@@ -968,6 +973,7 @@ void InxVkCoreModular::CreateMaterialShadowPipeline(std::shared_ptr<InxMaterial>
         return;
     }
 
+    m_shadowPipelineCache[shadowShaderKey] = shadowPipeline;
     material->SetPassPipeline(ShaderCompileTarget::Shadow, shadowPipeline);
     INXLOG_DEBUG("Created per-material shadow pipeline for '", material->GetName(), "'");
 }

--- a/cpp/infernux/function/renderer/gui/InxGUI.cpp
+++ b/cpp/infernux/function/renderer/gui/InxGUI.cpp
@@ -341,97 +341,102 @@ void InxGUI::BuildFrame()
         io.MouseWheelH = 0.0f;
     }
 
-    // Create a full-screen DockSpace (reserve bottom strip for the Python status bar)
-    const float kStatusBarHeight = 24.0f * m_dpiScale; // must match _HEIGHT in status_bar.py
-    ImGuiViewport *viewport = ImGui::GetMainViewport();
-    ImGui::SetNextWindowPos(viewport->WorkPos);
-    ImGui::SetNextWindowSize(ImVec2(viewport->WorkSize.x, viewport->WorkSize.y - kStatusBarHeight));
-    ImGui::SetNextWindowViewport(viewport->ID);
+    // In player mode, skip DockSpace/DockBuilder entirely — they are only
+    // needed for the editor's multi-panel layout.  The player registers a
+    // single full-screen renderable (PlayerGUI), so docking is wasted work.
+    if (!m_playerMode) {
+        // Create a full-screen DockSpace (reserve bottom strip for the Python status bar)
+        const float kStatusBarHeight = 24.0f * m_dpiScale; // must match _HEIGHT in status_bar.py
+        ImGuiViewport *viewport = ImGui::GetMainViewport();
+        ImGui::SetNextWindowPos(viewport->WorkPos);
+        ImGui::SetNextWindowSize(ImVec2(viewport->WorkSize.x, viewport->WorkSize.y - kStatusBarHeight));
+        ImGui::SetNextWindowViewport(viewport->ID);
 
-    ImGuiWindowFlags dockSpaceFlags = ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoTitleBar |
-                                      ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize |
-                                      ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus |
-                                      ImGuiWindowFlags_NoNavFocus | ImGuiWindowFlags_NoBackground;
+        ImGuiWindowFlags dockSpaceFlags = ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoTitleBar |
+                                          ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize |
+                                          ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBringToFrontOnFocus |
+                                          ImGuiWindowFlags_NoNavFocus | ImGuiWindowFlags_NoBackground;
 
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0.0f);
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0.0f);
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(0.0f, 0.0f));
 
-    ImGui::Begin("DockSpaceWindow", nullptr, dockSpaceFlags);
-    ImGui::PopStyleVar(3);
+        ImGui::Begin("DockSpaceWindow", nullptr, dockSpaceFlags);
+        ImGui::PopStyleVar(3);
 
-    // Check whether a saved layout already exists BEFORE DockSpace()
-    // creates the node.  If the node doesn't exist yet (first launch or
-    // imgui.ini was deleted by the Python layout-version mechanism), we
-    // need to build the default Unity-style layout.
-    ImGuiID dockspaceId = ImGui::GetID("MainDockSpace");
-    bool needsDefaultLayout = (ImGui::DockBuilderGetNode(dockspaceId) == nullptr);
+        // Check whether a saved layout already exists BEFORE DockSpace()
+        // creates the node.  If the node doesn't exist yet (first launch or
+        // imgui.ini was deleted by the Python layout-version mechanism), we
+        // need to build the default Unity-style layout.
+        ImGuiID dockspaceId = ImGui::GetID("MainDockSpace");
+        bool needsDefaultLayout = (ImGui::DockBuilderGetNode(dockspaceId) == nullptr);
 
-    ImGui::DockSpace(dockspaceId, ImVec2(0.0f, 0.0f), ImGuiDockNodeFlags_None);
+        ImGui::DockSpace(dockspaceId, ImVec2(0.0f, 0.0f), ImGuiDockNodeFlags_None);
 
-    // Setup default Unity-style layout only when no saved layout exists.
-    // This preserves user customizations across restarts while still
-    // providing the correct initial tab arrangement on first launch
-    // (or after a layout-version bump that deletes imgui.ini).
-    if (needsDefaultLayout) {
+        // Setup default Unity-style layout only when no saved layout exists.
+        // This preserves user customizations across restarts while still
+        // providing the correct initial tab arrangement on first launch
+        // (or after a layout-version bump that deletes imgui.ini).
+        if (needsDefaultLayout) {
 
-        ImGui::DockBuilderRemoveNode(dockspaceId);
-        ImGui::DockBuilderAddNode(dockspaceId, ImGuiDockNodeFlags_DockSpace);
-        ImGui::DockBuilderSetNodeSize(dockspaceId,
-                                      ImVec2(viewport->WorkSize.x, viewport->WorkSize.y - kStatusBarHeight));
+            ImGui::DockBuilderRemoveNode(dockspaceId);
+            ImGui::DockBuilderAddNode(dockspaceId, ImGuiDockNodeFlags_DockSpace);
+            ImGui::DockBuilderSetNodeSize(dockspaceId,
+                                          ImVec2(viewport->WorkSize.x, viewport->WorkSize.y - kStatusBarHeight));
 
-        // Split: Main area | Right panel (Inspector)
-        ImGuiID dockMain;
-        ImGuiID dockRight;
-        ImGui::DockBuilderSplitNode(dockspaceId, ImGuiDir_Right, 0.25f, &dockRight, &dockMain);
+            // Split: Main area | Right panel (Inspector)
+            ImGuiID dockMain;
+            ImGuiID dockRight;
+            ImGui::DockBuilderSplitNode(dockspaceId, ImGuiDir_Right, 0.25f, &dockRight, &dockMain);
 
-        // Split main: Top area (Hierarchy+Scene) | Bottom (Console/Project)
-        ImGuiID dockTop;
-        ImGuiID dockBottom;
-        ImGui::DockBuilderSplitNode(dockMain, ImGuiDir_Down, 0.30f, &dockBottom, &dockTop);
+            // Split main: Top area (Hierarchy+Scene) | Bottom (Console/Project)
+            ImGuiID dockTop;
+            ImGuiID dockBottom;
+            ImGui::DockBuilderSplitNode(dockMain, ImGuiDir_Down, 0.30f, &dockBottom, &dockTop);
 
-        // Split top: Left (Hierarchy) | Center-top (Toolbar+Scene)
-        ImGuiID dockLeft;
-        ImGuiID dockCenterTop;
-        ImGui::DockBuilderSplitNode(dockTop, ImGuiDir_Left, 0.20f, &dockLeft, &dockCenterTop);
+            // Split top: Left (Hierarchy) | Center-top (Toolbar+Scene)
+            ImGuiID dockLeft;
+            ImGuiID dockCenterTop;
+            ImGui::DockBuilderSplitNode(dockTop, ImGuiDir_Left, 0.20f, &dockLeft, &dockCenterTop);
 
-        // Split center-top: Toolbar (thin strip) | Scene/Game
-        ImGuiID dockToolbar;
-        ImGuiID dockScene;
-        ImGui::DockBuilderSplitNode(dockCenterTop, ImGuiDir_Up, 0.04f, &dockToolbar, &dockScene);
+            // Split center-top: Toolbar (thin strip) | Scene/Game
+            ImGuiID dockToolbar;
+            ImGuiID dockScene;
+            ImGui::DockBuilderSplitNode(dockCenterTop, ImGuiDir_Up, 0.04f, &dockToolbar, &dockScene);
 
-        // Set a fixed size for the toolbar node so it doesn't stretch
-        ImGui::DockBuilderSetNodeSize(dockToolbar, ImVec2(viewport->WorkSize.x, 36));
+            // Set a fixed size for the toolbar node so it doesn't stretch
+            ImGui::DockBuilderSetNodeSize(dockToolbar, ImVec2(viewport->WorkSize.x, 36));
 
-        // Hide tab bar on toolbar node — it should be locked in place
-        ImGuiDockNode *toolbarNode = ImGui::DockBuilderGetNode(dockToolbar);
-        if (toolbarNode) {
-            toolbarNode->SetLocalFlags(toolbarNode->LocalFlags | ImGuiDockNodeFlags_NoTabBar |
-                                       ImGuiDockNodeFlags_NoDockingSplit | ImGuiDockNodeFlags_NoResize |
-                                       ImGuiDockNodeFlags_NoUndocking);
+            // Hide tab bar on toolbar node — it should be locked in place
+            ImGuiDockNode *toolbarNode = ImGui::DockBuilderGetNode(dockToolbar);
+            if (toolbarNode) {
+                toolbarNode->SetLocalFlags(toolbarNode->LocalFlags | ImGuiDockNodeFlags_NoTabBar |
+                                           ImGuiDockNodeFlags_NoDockingSplit | ImGuiDockNodeFlags_NoResize |
+                                           ImGuiDockNodeFlags_NoUndocking);
+            }
+
+            // Dock windows to their positions.
+            // Window IDs use the ### separator so the docking layout is
+            // independent of the displayed (localised) title.  The text
+            // before ### is ignored for ID purposes; only the part after
+            // ### must match what the Python panel passes to ImGui::Begin.
+            ImGui::DockBuilderDockWindow("###hierarchy", dockLeft);
+            ImGui::DockBuilderDockWindow("###inspector", dockRight);
+            ImGui::DockBuilderDockWindow("###toolbar", dockToolbar);
+            ImGui::DockBuilderDockWindow("###scene_view", dockScene);
+            ImGui::DockBuilderDockWindow("###game_view", dockScene);
+            ImGui::DockBuilderDockWindow("###ui_editor", dockScene);
+            ImGui::DockBuilderDockWindow("###console", dockBottom);
+            ImGui::DockBuilderDockWindow("###project", dockBottom);
+
+            ImGui::DockBuilderFinish(dockspaceId);
+
+            // Ensure Scene tab is the active/selected tab after initial layout
+            ImGui::SetWindowFocus("###scene_view");
         }
 
-        // Dock windows to their positions.
-        // Window IDs use the ### separator so the docking layout is
-        // independent of the displayed (localised) title.  The text
-        // before ### is ignored for ID purposes; only the part after
-        // ### must match what the Python panel passes to ImGui::Begin.
-        ImGui::DockBuilderDockWindow("###hierarchy", dockLeft);
-        ImGui::DockBuilderDockWindow("###inspector", dockRight);
-        ImGui::DockBuilderDockWindow("###toolbar", dockToolbar);
-        ImGui::DockBuilderDockWindow("###scene_view", dockScene);
-        ImGui::DockBuilderDockWindow("###game_view", dockScene);
-        ImGui::DockBuilderDockWindow("###ui_editor", dockScene);
-        ImGui::DockBuilderDockWindow("###console", dockBottom);
-        ImGui::DockBuilderDockWindow("###project", dockBottom);
-
-        ImGui::DockBuilderFinish(dockspaceId);
-
-        // Ensure Scene tab is the active/selected tab after initial layout
-        ImGui::SetWindowFocus("###scene_view");
-    }
-
-    ImGui::End();
+        ImGui::End();
+    } // !m_playerMode
 
     using hrc = std::chrono::high_resolution_clock;
     m_lastPanelTimesMs.clear();

--- a/cpp/infernux/function/renderer/gui/InxGUI.h
+++ b/cpp/infernux/function/renderer/gui/InxGUI.h
@@ -34,7 +34,10 @@ class InxGUI
     void RecordCommand(VkCommandBuffer cmdBuf);
     void Shutdown();
 
-    void SetPlayerMode(bool enabled) { m_playerMode = enabled; }
+    void SetPlayerMode(bool enabled)
+    {
+        m_playerMode = enabled;
+    }
 
     [[nodiscard]] const std::unordered_map<std::string, double> &GetLastPanelTimesMs() const
     {

--- a/cpp/infernux/function/renderer/gui/InxGUI.h
+++ b/cpp/infernux/function/renderer/gui/InxGUI.h
@@ -34,6 +34,8 @@ class InxGUI
     void RecordCommand(VkCommandBuffer cmdBuf);
     void Shutdown();
 
+    void SetPlayerMode(bool enabled) { m_playerMode = enabled; }
+
     [[nodiscard]] const std::unordered_map<std::string, double> &GetLastPanelTimesMs() const
     {
         return m_lastPanelTimesMs;
@@ -108,6 +110,7 @@ class InxGUI
     std::unordered_map<std::string, double> m_lastPanelTimesMs;
     std::unordered_map<std::string, ImGuiTextureResource> m_textures_umap;
     ResourcePreviewManager m_resourcePreviewManager;
+    bool m_playerMode = false;
 
     void ApplyPendingDockTabSelections();
 };

--- a/cpp/infernux/function/resources/InxMaterial/InxMaterial.cpp
+++ b/cpp/infernux/function/resources/InxMaterial/InxMaterial.cpp
@@ -1,5 +1,6 @@
 #include "InxMaterial.h"
 #include <algorithm>
+#include <atomic>
 #include <core/log/InxLog.h>
 #include <cstring>
 #include <filesystem>
@@ -1058,6 +1059,47 @@ std::shared_ptr<InxMaterial> InxMaterial::CreateErrorMaterial()
     material->SetBuiltin(true);
 
     return material;
+}
+
+// ============================================================================
+// Clone — Unity-style Object.Instantiate for materials
+// ============================================================================
+
+std::shared_ptr<InxMaterial> InxMaterial::Clone() const
+{
+    static std::atomic<uint64_t> s_cloneCounter{0};
+    auto clone = std::make_shared<InxMaterial>();
+
+    // Deep copy identity (clear GUID & file path — runtime-only instance)
+    // Each clone gets a unique name so GetMaterialKey() returns a unique key,
+    // ensuring separate descriptor sets / UBOs in the renderer.
+    clone->m_name = m_name + " (Instance_" + std::to_string(s_cloneCounter.fetch_add(1)) + ")";
+    // clone->m_guid intentionally left empty — no asset identity
+    // clone->m_filePath intentionally left empty — not saved to disk
+    clone->m_builtin = false; // Clones are never builtin
+
+    // Deep copy shader identity
+    clone->m_vertShaderName = m_vertShaderName;
+    clone->m_fragShaderName = m_fragShaderName;
+    clone->m_passTag = m_passTag;
+
+    // Deep copy render state & overrides
+    clone->m_renderState = m_renderState;
+    clone->m_renderStateOverrides = m_renderStateOverrides;
+
+    // Deep copy all properties (floats, vecs, colors, texture GUIDs, etc.)
+    // Texture references are GUIDs (strings) — shared by value, same as Unity.
+    clone->m_properties = m_properties;
+
+    // GPU-transient state is NOT copied — lazily recreated by the renderer.
+    // m_passPipelines[] are already default-initialized (VK_NULL_HANDLE).
+    // m_uboBuffer etc. are already default-initialized (VK_NULL_HANDLE).
+    clone->m_pipelineDirty = true;
+    clone->m_propertiesDirty = true;
+    clone->m_version = 0;
+    clone->m_isDeleted = false;
+
+    return clone;
 }
 
 } // namespace infernux

--- a/cpp/infernux/function/resources/InxMaterial/InxMaterial.h
+++ b/cpp/infernux/function/resources/InxMaterial/InxMaterial.h
@@ -513,13 +513,23 @@ class InxMaterial
     /// @brief Create the error material (purple-black checkerboard for shader mismatch)
     static std::shared_ptr<InxMaterial> CreateErrorMaterial();
 
-  private:
-    friend class MaterialLoader;
+    // ========================================================================
+    // Clone (Unity-style Object.Instantiate for materials)
+    // ========================================================================
+
+    /// @brief Create a deep copy of this material (Unity: Object.Instantiate).
+    /// Copies all properties, shader names, and render state.
+    /// GPU-transient state (pipelines, UBO) is NOT copied — lazily recreated.
+    /// The clone has no GUID and no file path (runtime-only instance).
+    [[nodiscard]] std::shared_ptr<InxMaterial> Clone() const;
 
     void SetGuid(const std::string &guid)
     {
         m_guid = guid;
     }
+
+  private:
+    friend class MaterialLoader;
 
     std::string m_name;
     std::string m_guid;

--- a/cpp/infernux/function/resources/InxTexture/InxTexture.cpp
+++ b/cpp/infernux/function/resources/InxTexture/InxTexture.cpp
@@ -33,4 +33,26 @@ bool InxTexture::LoadImportSettings(const std::string &filePath)
     return true;
 }
 
+// =============================================================================
+// Clone — Unity-style Object.Instantiate for textures
+// =============================================================================
+
+std::shared_ptr<InxTexture> InxTexture::Clone() const
+{
+    auto clone = std::make_shared<InxTexture>();
+
+    // Copy metadata — the clone references the same image file on disk.
+    clone->m_name = m_name + " (Instance)";
+    clone->m_filePath = m_filePath; // Same source file
+    // clone->m_guid intentionally left empty — runtime-only instance
+
+    // Copy import settings
+    clone->m_textureType = m_textureType;
+    clone->m_srgb = m_srgb;
+    clone->m_generateMipmaps = m_generateMipmaps;
+    clone->m_maxSize = m_maxSize;
+
+    return clone;
+}
+
 } // namespace infernux

--- a/cpp/infernux/function/resources/InxTexture/InxTexture.h
+++ b/cpp/infernux/function/resources/InxTexture/InxTexture.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 
 namespace infernux
@@ -106,6 +107,14 @@ class InxTexture
     /// Load (or refresh) import settings from the .meta file.
     /// @return true if .meta was found and parsed.
     bool LoadImportSettings(const std::string &filePath);
+
+    // ── Clone (Unity-style Object.Instantiate) ─────────────────────────────
+
+    /// @brief Create a copy of this texture metadata (import settings).
+    /// GPU pixel data is NOT duplicated — the clone references the same
+    /// underlying image file.  Matches Unity behavior where Instantiate
+    /// on a Texture2D copies the CPU-side metadata.
+    [[nodiscard]] std::shared_ptr<InxTexture> Clone() const;
 
   private:
     std::string m_guid;

--- a/cpp/infernux/function/scene/Component.h
+++ b/cpp/infernux/function/scene/Component.h
@@ -14,6 +14,7 @@ class GameObject;
 class Transform;
 class Collider;
 struct CollisionInfo;
+void InvalidateGameObjectLifecycleCaches(GameObject *gameObject);
 
 /**
  * @brief Base class for all components that can be attached to GameObjects.
@@ -263,7 +264,13 @@ class Component
     /// @brief Set per-component execution order (Unity-style script order baseline).
     void SetExecutionOrder(int order)
     {
+        if (m_executionOrder == order) {
+            return;
+        }
         m_executionOrder = order;
+        if (m_gameObject) {
+            InvalidateGameObjectLifecycleCaches(m_gameObject);
+        }
     }
 
     /// @brief Get component type name for serialization/debugging

--- a/cpp/infernux/function/scene/GameObject.cpp
+++ b/cpp/infernux/function/scene/GameObject.cpp
@@ -6,6 +6,7 @@
 #include "PyComponentProxy.h"
 #include "Rigidbody.h"
 #include "Scene.h"
+#include "function/audio/AudioSource.h"
 #include "physics/PhysicsWorld.h"
 #include <InxLog.h>
 #include <algorithm>
@@ -19,6 +20,16 @@ using json = nlohmann::json;
 
 namespace infernux
 {
+
+void InvalidateGameObjectLifecycleCaches(GameObject *gameObject)
+{
+    if (!gameObject) {
+        return;
+    }
+
+    gameObject->InvalidateComponentExecutionCache();
+    gameObject->RefreshLifecycleDispatchFlags();
+}
 
 // Static ID generator
 static std::atomic<uint64_t> s_nextID{1};
@@ -132,7 +143,7 @@ void GameObject::HandleActiveStateChanged(bool wasActiveInHierarchy, bool isActi
     }
 
     if (isActiveInHierarchy) {
-        std::vector<Component *> components = GetComponentsInExecutionOrder();
+        const auto &components = GetComponentsInExecutionOrderCached();
         for (Component *comp : components) {
             if (!comp)
                 continue;
@@ -149,7 +160,7 @@ void GameObject::HandleActiveStateChanged(bool wasActiveInHierarchy, bool isActi
             }
         }
     } else {
-        std::vector<Component *> components = GetComponentsInExecutionOrder();
+        const auto &components = GetComponentsInExecutionOrderCached();
         for (Component *comp : components) {
             if (!comp)
                 continue;
@@ -174,23 +185,65 @@ void GameObject::HandleActiveStateChanged(bool wasActiveInHierarchy, bool isActi
 
 std::vector<Component *> GameObject::GetComponentsInExecutionOrder() const
 {
-    std::vector<Component *> result;
-    result.reserve(m_components.size());
+    return GetComponentsInExecutionOrderCached();
+}
+
+const std::vector<Component *> &GameObject::GetComponentsInExecutionOrderCached() const
+{
+    if (!m_executionOrderCacheDirty) {
+        return m_executionOrderCache;
+    }
+
+    m_executionOrderCache.clear();
+    m_executionOrderCache.reserve(m_components.size());
 
     for (const auto &comp : m_components) {
         if (comp) {
-            result.push_back(comp.get());
+            m_executionOrderCache.push_back(comp.get());
         }
     }
 
-    std::stable_sort(result.begin(), result.end(), [](const Component *a, const Component *b) {
-        if (a->GetExecutionOrder() != b->GetExecutionOrder()) {
-            return a->GetExecutionOrder() < b->GetExecutionOrder();
-        }
-        return a->GetComponentID() < b->GetComponentID();
-    });
+    std::stable_sort(m_executionOrderCache.begin(), m_executionOrderCache.end(),
+                     [](const Component *a, const Component *b) {
+                         if (a->GetExecutionOrder() != b->GetExecutionOrder()) {
+                             return a->GetExecutionOrder() < b->GetExecutionOrder();
+                         }
+                         return a->GetComponentID() < b->GetComponentID();
+                     });
 
-    return result;
+    m_executionOrderCacheDirty = false;
+    return m_executionOrderCache;
+}
+
+void GameObject::InvalidateComponentExecutionCache()
+{
+    m_executionOrderCacheDirty = true;
+}
+
+void GameObject::RefreshLifecycleDispatchFlags()
+{
+    m_hasPyProxy = false;
+    m_hasUpdateReceivers = false;
+    m_hasFixedUpdateReceivers = false;
+    m_hasLateUpdateReceivers = false;
+
+    for (const auto &component : m_components) {
+        if (!component) {
+            continue;
+        }
+
+        if (dynamic_cast<PyComponentProxy *>(component.get())) {
+            m_hasPyProxy = true;
+            m_hasUpdateReceivers = true;
+            m_hasFixedUpdateReceivers = true;
+            m_hasLateUpdateReceivers = true;
+            continue;
+        }
+
+        if (dynamic_cast<AudioSource *>(component.get())) {
+            m_hasUpdateReceivers = true;
+        }
+    }
 }
 
 void GameObject::SetActive(bool active)
@@ -323,11 +376,8 @@ void GameObject::PostAddComponent(Component *component)
     }
 
     m_scene->BumpStructureVersion();
-
-    // Track whether this object has a PyComponentProxy for LateUpdate fast-path.
-    if (dynamic_cast<PyComponentProxy *>(component)) {
-        m_hasPyProxy = true;
-    }
+    InvalidateComponentExecutionCache();
+    RefreshLifecycleDispatchFlags();
 
     // Auto-add a BoxCollider when Rigidbody is added to an object without
     // any Collider.  Physics engines require at least one shape for a body.
@@ -387,23 +437,13 @@ bool GameObject::RemoveComponent(Component *component)
 
     for (auto it = m_components.begin(); it != m_components.end(); ++it) {
         if (it->get() == component) {
-            // Clear PyProxy flag if removing the last PyComponentProxy.
-            if (dynamic_cast<PyComponentProxy *>(component)) {
-                bool otherProxy = false;
-                for (const auto &c : m_components) {
-                    if (c.get() != component && dynamic_cast<PyComponentProxy *>(c.get())) {
-                        otherProxy = true;
-                        break;
-                    }
-                }
-                if (!otherProxy)
-                    m_hasPyProxy = false;
-            }
             (*it)->CallOnDestroy();
             m_components.erase(it);
             if (m_scene) {
                 m_scene->BumpStructureVersion();
             }
+            InvalidateComponentExecutionCache();
+            RefreshLifecycleDispatchFlags();
             return true;
         }
     }
@@ -535,11 +575,10 @@ GameObject *GameObject::FindDescendant(const std::string &name) const
 
 void GameObject::Update(float deltaTime)
 {
-    if (!m_active)
+    if (!m_active || !m_hasUpdateReceivers)
         return;
 
-    // Update all components
-    std::vector<Component *> components = GetComponentsInExecutionOrder();
+    const auto &components = GetComponentsInExecutionOrderCached();
     for (Component *comp : components) {
         if (!comp)
             continue;
@@ -553,10 +592,10 @@ void GameObject::Update(float deltaTime)
 
 void GameObject::FixedUpdate(float fixedDeltaTime)
 {
-    if (!m_active)
+    if (!m_active || !m_hasFixedUpdateReceivers)
         return;
 
-    std::vector<Component *> components = GetComponentsInExecutionOrder();
+    const auto &components = GetComponentsInExecutionOrderCached();
     for (Component *comp : components) {
         if (!comp)
             continue;
@@ -570,17 +609,10 @@ void GameObject::FixedUpdate(float fixedDeltaTime)
 
 void GameObject::LateUpdate(float deltaTime)
 {
-    if (!m_active)
+    if (!m_active || !m_hasLateUpdateReceivers)
         return;
 
-    // Fast path: only PyComponentProxy overrides LateUpdate / TickWhileDisabledLateUpdate.
-    // Skip the expensive GetComponentsInExecutionOrder() allocation + sort
-    // for objects that have no Python proxy.
-    if (!m_hasPyProxy)
-        return;
-
-    // LateUpdate all components
-    std::vector<Component *> components = GetComponentsInExecutionOrder();
+    const auto &components = GetComponentsInExecutionOrderCached();
     for (Component *comp : components) {
         if (!comp)
             continue;
@@ -597,7 +629,7 @@ void GameObject::EditorUpdate(float deltaTime)
     if (!m_active)
         return;
 
-    std::vector<Component *> components = GetComponentsInExecutionOrder();
+    const auto &components = GetComponentsInExecutionOrderCached();
     for (Component *comp : components) {
         if (!comp || !comp->IsEnabled())
             continue;

--- a/cpp/infernux/function/scene/GameObject.cpp
+++ b/cpp/infernux/function/scene/GameObject.cpp
@@ -324,6 +324,11 @@ void GameObject::PostAddComponent(Component *component)
 
     m_scene->BumpStructureVersion();
 
+    // Track whether this object has a PyComponentProxy for LateUpdate fast-path.
+    if (dynamic_cast<PyComponentProxy *>(component)) {
+        m_hasPyProxy = true;
+    }
+
     // Auto-add a BoxCollider when Rigidbody is added to an object without
     // any Collider.  Physics engines require at least one shape for a body.
     if (dynamic_cast<Rigidbody *>(component) && !HasComponent<Collider>()) {
@@ -382,6 +387,18 @@ bool GameObject::RemoveComponent(Component *component)
 
     for (auto it = m_components.begin(); it != m_components.end(); ++it) {
         if (it->get() == component) {
+            // Clear PyProxy flag if removing the last PyComponentProxy.
+            if (dynamic_cast<PyComponentProxy *>(component)) {
+                bool otherProxy = false;
+                for (const auto &c : m_components) {
+                    if (c.get() != component && dynamic_cast<PyComponentProxy *>(c.get())) {
+                        otherProxy = true;
+                        break;
+                    }
+                }
+                if (!otherProxy)
+                    m_hasPyProxy = false;
+            }
             (*it)->CallOnDestroy();
             m_components.erase(it);
             if (m_scene) {
@@ -554,6 +571,12 @@ void GameObject::FixedUpdate(float fixedDeltaTime)
 void GameObject::LateUpdate(float deltaTime)
 {
     if (!m_active)
+        return;
+
+    // Fast path: only PyComponentProxy overrides LateUpdate / TickWhileDisabledLateUpdate.
+    // Skip the expensive GetComponentsInExecutionOrder() allocation + sort
+    // for objects that have no Python proxy.
+    if (!m_hasPyProxy)
         return;
 
     // LateUpdate all components

--- a/cpp/infernux/function/scene/GameObject.h
+++ b/cpp/infernux/function/scene/GameObject.h
@@ -441,6 +441,7 @@ class GameObject
     bool m_active = true;
     bool m_isStatic = false;
     bool m_persistent = false;
+    bool m_hasPyProxy = false; // true when a PyComponentProxy is attached
     std::string m_tag = "Untagged";
     int m_layer = 0; // Default layer
 

--- a/cpp/infernux/function/scene/GameObject.h
+++ b/cpp/infernux/function/scene/GameObject.h
@@ -302,11 +302,7 @@ class GameObject
 
         for (auto it = m_components.begin(); it != m_components.end(); ++it) {
             if (dynamic_cast<T *>(it->get())) {
-                if (!CanRemoveComponent(it->get()))
-                    return false;
-                (*it)->CallOnDestroy();
-                m_components.erase(it);
-                return true;
+                return RemoveComponent(it->get());
             }
         }
         return false;
@@ -426,11 +422,15 @@ class GameObject
   private:
     friend class Scene;
     friend class SceneManager;
+    friend void InvalidateGameObjectLifecycleCaches(GameObject *gameObject);
 
     void SetScene(Scene *scene);
 
     void PostAddComponent(Component *component);
     void HandleActiveStateChanged(bool wasActiveInHierarchy, bool isActiveInHierarchy);
+    void InvalidateComponentExecutionCache();
+    void RefreshLifecycleDispatchFlags();
+    [[nodiscard]] const std::vector<Component *> &GetComponentsInExecutionOrderCached() const;
 
     void CollectAllDescendants(std::vector<GameObject *> &out) const;
 
@@ -442,11 +442,16 @@ class GameObject
     bool m_isStatic = false;
     bool m_persistent = false;
     bool m_hasPyProxy = false; // true when a PyComponentProxy is attached
+    bool m_hasUpdateReceivers = false;
+    bool m_hasFixedUpdateReceivers = false;
+    bool m_hasLateUpdateReceivers = false;
     std::string m_tag = "Untagged";
     int m_layer = 0; // Default layer
 
     Transform m_transform;
     std::vector<std::unique_ptr<Component>> m_components;
+    mutable std::vector<Component *> m_executionOrderCache;
+    mutable bool m_executionOrderCacheDirty = true;
 
     GameObject *m_parent = nullptr;
     std::vector<std::unique_ptr<GameObject>> m_children;

--- a/cpp/infernux/function/scene/PyComponentProxy.cpp
+++ b/cpp/infernux/function/scene/PyComponentProxy.cpp
@@ -114,6 +114,19 @@ PyComponentProxy::PyComponentProxy(py::object pyComponent)
             py::object pyType = m_pyComponent.attr("__class__");
             m_typeName = pyType.attr("__name__").cast<std::string>();
 
+            try {
+                py::object inxComponentType = py::module_::import("Infernux.components").attr("InxComponent");
+                m_overridesUpdate = !pyType.attr("update").is(inxComponentType.attr("update"));
+                m_overridesFixedUpdate = !pyType.attr("fixed_update").is(inxComponentType.attr("fixed_update"));
+                m_overridesLateUpdate = !pyType.attr("late_update").is(inxComponentType.attr("late_update"));
+            } catch (const py::error_already_set &e) {
+                INXLOG_WARN("[PyComponentProxy] Failed to inspect lifecycle overrides for '", m_typeName,
+                            "': ", e.what());
+                m_overridesUpdate = true;
+                m_overridesFixedUpdate = true;
+                m_overridesLateUpdate = true;
+            }
+
             if (py::hasattr(pyType, "_execute_in_edit_mode_")) {
                 try {
                     m_executeInEditMode = pyType.attr("_execute_in_edit_mode_").cast<bool>();
@@ -143,6 +156,8 @@ PyComponentProxy::PyComponentProxy(py::object pyComponent)
                     m_scriptGuid = guidAttr.cast<std::string>();
                 }
             }
+
+            RefreshCoroutineSchedulerFlag();
         } catch (const py::error_already_set &e) {
             INXLOG_ERROR("[PyComponentProxy] Failed to get type name: ", e.what());
         }
@@ -158,7 +173,10 @@ PyComponentProxy::~PyComponentProxy()
 
 PyComponentProxy::PyComponentProxy(PyComponentProxy &&other) noexcept
     : Component(std::move(other)), m_pyComponent(std::move(other.m_pyComponent)),
-      m_typeName(std::move(other.m_typeName)), m_typeGuid(std::move(other.m_typeGuid))
+      m_typeName(std::move(other.m_typeName)), m_typeGuid(std::move(other.m_typeGuid)),
+      m_scriptGuid(std::move(other.m_scriptGuid)), m_executeInEditMode(other.m_executeInEditMode),
+      m_overridesUpdate(other.m_overridesUpdate), m_overridesFixedUpdate(other.m_overridesFixedUpdate),
+      m_overridesLateUpdate(other.m_overridesLateUpdate), m_hasCoroutineScheduler(other.m_hasCoroutineScheduler)
 {
     other.m_pyComponent = py::none();
 }
@@ -170,9 +188,35 @@ PyComponentProxy &PyComponentProxy::operator=(PyComponentProxy &&other) noexcept
         m_pyComponent = std::move(other.m_pyComponent);
         m_typeName = std::move(other.m_typeName);
         m_typeGuid = std::move(other.m_typeGuid);
+        m_scriptGuid = std::move(other.m_scriptGuid);
+        m_executeInEditMode = other.m_executeInEditMode;
+        m_overridesUpdate = other.m_overridesUpdate;
+        m_overridesFixedUpdate = other.m_overridesFixedUpdate;
+        m_overridesLateUpdate = other.m_overridesLateUpdate;
+        m_hasCoroutineScheduler = other.m_hasCoroutineScheduler;
         other.m_pyComponent = py::none();
     }
     return *this;
+}
+
+void PyComponentProxy::RefreshCoroutineSchedulerFlag()
+{
+    if (m_pyComponent.is_none()) {
+        m_hasCoroutineScheduler = false;
+        return;
+    }
+
+    try {
+        if (!py::hasattr(m_pyComponent, "_coroutine_scheduler")) {
+            m_hasCoroutineScheduler = false;
+            return;
+        }
+
+        m_hasCoroutineScheduler = !m_pyComponent.attr("_coroutine_scheduler").is_none();
+    } catch (const py::error_already_set &e) {
+        INXLOG_WARN("[PyComponentProxy] Failed to inspect coroutine scheduler for '", m_typeName, "': ", e.what());
+        m_hasCoroutineScheduler = true;
+    }
 }
 
 void PyComponentProxy::BindPythonMirror()
@@ -207,6 +251,7 @@ void PyComponentProxy::Awake()
 
         // Call Python awake
         CallPythonLifecycleNoArg(m_pyComponent, m_typeName, "_call_awake", "awake");
+        RefreshCoroutineSchedulerFlag();
         SyncPythonMirror();
     } catch (const py::error_already_set &e) {
         INXLOG_ERROR("[PyComponentProxy] Error in ", m_typeName, ".awake setup: ", e.what());
@@ -220,6 +265,7 @@ void PyComponentProxy::OnEnable()
 
     SyncPythonMirror();
     CallPythonLifecycleNoArg(m_pyComponent, m_typeName, "_call_on_enable", "on_enable");
+    RefreshCoroutineSchedulerFlag();
 }
 
 void PyComponentProxy::Start()
@@ -228,6 +274,7 @@ void PyComponentProxy::Start()
         return;
 
     CallPythonLifecycleNoArg(m_pyComponent, m_typeName, "_call_start", "start");
+    RefreshCoroutineSchedulerFlag();
     SyncPythonMirror();
 }
 
@@ -236,7 +283,11 @@ void PyComponentProxy::Update(float deltaTime)
     if (m_pyComponent.is_none())
         return;
 
+    if (!m_overridesUpdate && !m_hasCoroutineScheduler)
+        return;
+
     CallPythonLifecycleFloatArg(m_pyComponent, m_typeName, "_call_update", "update", deltaTime);
+    RefreshCoroutineSchedulerFlag();
 }
 
 void PyComponentProxy::FixedUpdate(float fixedDeltaTime)
@@ -244,7 +295,11 @@ void PyComponentProxy::FixedUpdate(float fixedDeltaTime)
     if (m_pyComponent.is_none())
         return;
 
+    if (!m_overridesFixedUpdate && !m_hasCoroutineScheduler)
+        return;
+
     CallPythonLifecycleFloatArg(m_pyComponent, m_typeName, "_call_fixed_update", "fixed_update", fixedDeltaTime);
+    RefreshCoroutineSchedulerFlag();
 }
 
 void PyComponentProxy::LateUpdate(float deltaTime)
@@ -252,34 +307,41 @@ void PyComponentProxy::LateUpdate(float deltaTime)
     if (m_pyComponent.is_none())
         return;
 
+    if (!m_overridesLateUpdate && !m_hasCoroutineScheduler)
+        return;
+
     CallPythonLifecycleFloatArg(m_pyComponent, m_typeName, "_call_late_update", "late_update", deltaTime);
+    RefreshCoroutineSchedulerFlag();
 }
 
 void PyComponentProxy::TickWhileDisabledUpdate(float deltaTime)
 {
-    if (m_pyComponent.is_none())
+    if (m_pyComponent.is_none() || !m_hasCoroutineScheduler)
         return;
 
     CallPythonLifecycleFloatArg(m_pyComponent, m_typeName, "_tick_coroutines_update", "tick_coroutines_update",
                                 deltaTime);
+    RefreshCoroutineSchedulerFlag();
 }
 
 void PyComponentProxy::TickWhileDisabledFixedUpdate(float fixedDeltaTime)
 {
-    if (m_pyComponent.is_none())
+    if (m_pyComponent.is_none() || !m_hasCoroutineScheduler)
         return;
 
     CallPythonLifecycleFloatArg(m_pyComponent, m_typeName, "_tick_coroutines_fixed_update",
                                 "tick_coroutines_fixed_update", fixedDeltaTime);
+    RefreshCoroutineSchedulerFlag();
 }
 
 void PyComponentProxy::TickWhileDisabledLateUpdate(float deltaTime)
 {
-    if (m_pyComponent.is_none())
+    if (m_pyComponent.is_none() || !m_hasCoroutineScheduler)
         return;
 
     CallPythonLifecycleFloatArg(m_pyComponent, m_typeName, "_tick_coroutines_late_update",
                                 "tick_coroutines_late_update", deltaTime);
+    RefreshCoroutineSchedulerFlag();
 }
 
 void PyComponentProxy::OnDisable()

--- a/cpp/infernux/function/scene/PyComponentProxy.h
+++ b/cpp/infernux/function/scene/PyComponentProxy.h
@@ -146,12 +146,17 @@ class PyComponentProxy : public Component
   private:
     void BindPythonMirror();
     void SyncPythonMirror() const;
+    void RefreshCoroutineSchedulerFlag();
 
     py::object m_pyComponent;
     std::string m_typeName;
     std::string m_typeGuid;   // Stable type GUID (hash of module.classname)
     std::string m_scriptGuid; // Stable GUID for the script asset
     bool m_executeInEditMode = false;
+    bool m_overridesUpdate = true;
+    bool m_overridesFixedUpdate = true;
+    bool m_overridesLateUpdate = true;
+    bool m_hasCoroutineScheduler = false;
 };
 
 } // namespace infernux

--- a/cpp/infernux/tools/pybinding/BindingInfernux.cpp
+++ b/cpp/infernux/tools/pybinding/BindingInfernux.cpp
@@ -568,6 +568,14 @@ PYBIND11_MODULE(_Infernux, m)
             },
             py::arg("visible"), "Enable/disable scene view rendering")
         .def(
+            "set_gui_player_mode",
+            [](Infernux &self, bool enabled) {
+                auto *r = self.GetRenderer();
+                if (r)
+                    r->SetGUIPlayerMode(enabled);
+            },
+            py::arg("enabled"), "Skip DockSpace/layout overhead in standalone player mode")
+        .def(
             "is_game_camera_enabled",
             [](Infernux &self) -> bool {
                 auto *r = self.GetRenderer();

--- a/cpp/infernux/tools/pybinding/BindingResources.cpp
+++ b/cpp/infernux/tools/pybinding/BindingResources.cpp
@@ -546,7 +546,22 @@ void RegisterResourceBindings(py::module_ &m)
         .def("has_override", &InxMaterial::HasOverride, py::arg("flag"),
              "Check if a RenderState field is user-overridden")
         .def("sync_alpha_clip_property", &InxMaterial::SyncAlphaClipProperty,
-             "Sync internal _AlphaClipThreshold material property from RenderState");
+             "Sync internal _AlphaClipThreshold material property from RenderState")
+        // Clone / Instantiate (Unity-style Object.Instantiate for materials)
+        .def("clone", &InxMaterial::Clone,
+             "Create a deep copy of this material (Unity: new Material(original)). "
+             "Copies all properties, shader names, and render state. "
+             "GPU state is lazily recreated. The clone has no GUID (runtime-only).")
+        .def_static(
+            "instantiate",
+            [](const std::shared_ptr<InxMaterial> &original) -> std::shared_ptr<InxMaterial> {
+                if (!original)
+                    return nullptr;
+                return original->Clone();
+            },
+            py::arg("original"),
+            "Clone a material (Unity: Object.Instantiate). Deep-copies all properties; "
+            "shader and texture references are shared. Returns a new runtime material instance.");
 
     // RenderStateOverride — bitmask flags for per-material render state overrides
     py::enum_<RenderStateOverride>(m, "RenderStateOverride", py::arithmetic())

--- a/python/Infernux/__init__.py
+++ b/python/Infernux/__init__.py
@@ -33,6 +33,7 @@ from Infernux.coroutine import (
     WaitWhile,
 )
 from Infernux.batch import batch_read, batch_write, create_batch_handle
+from Infernux.instantiate import Instantiate, Destroy
 
 
 def __getattr__(name: str):
@@ -157,4 +158,7 @@ __all__ = [
     # Batch processing
     "batch_read",
     "batch_write",
+    # Object lifecycle
+    "Instantiate",
+    "Destroy",
 ]

--- a/python/Infernux/components/builtin/mesh_renderer.py
+++ b/python/Infernux/components/builtin/mesh_renderer.py
@@ -23,10 +23,33 @@ from Infernux.components.builtin_component import BuiltinComponent, CppProperty
 from Infernux.components.serialized_field import FieldType
 
 
+def _to_native_material(value):
+    """Unwrap a Python Material wrapper to native InxMaterial.
+
+    Passes through strings (GUIDs) and None unchanged.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    native = getattr(value, "_native", None) or getattr(value, "native", None)
+    if native is not None:
+        return native
+    return value
+
+
 class MeshRenderer(BuiltinComponent):
     """Python wrapper for the C++ MeshRenderer component.
 
     Properties delegate to the C++ ``MeshRenderer`` via CppProperty.
+
+    Material properties follow Unity naming conventions:
+
+    * ``material`` / ``sharedMaterial`` \u2014 slot 0
+    * ``materials`` / ``sharedMaterials`` \u2014 all slots
+
+    Accepts any of: Python ``Material`` wrapper, native ``InxMaterial``,
+    GUID string, or ``None``.
     """
 
     _cpp_type_name = "MeshRenderer"
@@ -47,22 +70,59 @@ class MeshRenderer(BuiltinComponent):
     )
 
     # ------------------------------------------------------------------
-    # Material (slot 0 convenience — delegates to multi-material API)
+    # Material — Unity-style API
     # ------------------------------------------------------------------
 
     @property
-    def render_material(self):
-        """The material used for rendering (slot 0)."""
+    def material(self):
+        """The material for slot 0 (Unity-style)."""
         cpp = self._cpp_component
         if cpp is not None:
             return cpp.get_material(0)
         return None
 
-    @render_material.setter
-    def render_material(self, value) -> None:
+    @material.setter
+    def material(self, value) -> None:
         cpp = self._cpp_component
         if cpp is not None:
-            cpp.set_material(0, value)
+            cpp.set_material(0, _to_native_material(value))
+
+    @property
+    def sharedMaterial(self):
+        """Alias for ``material`` (Unity compatibility)."""
+        return self.material
+
+    @sharedMaterial.setter
+    def sharedMaterial(self, value) -> None:
+        self.material = value
+
+    @property
+    def materials(self) -> list:
+        """All materials across every slot (Unity-style)."""
+        cpp = self._cpp_component
+        if cpp is None:
+            return []
+        return [cpp.get_material(i) for i in range(cpp.material_count)]
+
+    @materials.setter
+    def materials(self, value: list) -> None:
+        cpp = self._cpp_component
+        if cpp is None:
+            return
+        for i, mat in enumerate(value):
+            cpp.set_material(i, _to_native_material(mat))
+
+    @property
+    def sharedMaterials(self) -> list:
+        """Alias for ``materials`` (Unity compatibility)."""
+        return self.materials
+
+    @sharedMaterials.setter
+    def sharedMaterials(self, value: list) -> None:
+        self.materials = value
+
+    # Legacy alias
+    render_material = material
 
     @property
     def material_guid(self) -> str:
@@ -81,20 +141,17 @@ class MeshRenderer(BuiltinComponent):
 
     def has_render_material(self) -> bool:
         """Check if a custom material is assigned at slot 0."""
-        cpp = self._cpp_component
-        if cpp is not None:
-            return cpp.get_material(0) is not None
-        return False
+        return self.material is not None
 
     def get_effective_material(self, slot: int = 0):
-        """Get the effective material for a given slot (custom or default)."""
+        """Get the effective material at slot (custom or default)."""
         cpp = self._cpp_component
         if cpp is not None:
             return cpp.get_effective_material(slot)
         return None
 
     # ------------------------------------------------------------------
-    # Multi-material API
+    # Multi-material API  (Unity Renderer alignment)
     # ------------------------------------------------------------------
 
     @property
@@ -105,6 +162,8 @@ class MeshRenderer(BuiltinComponent):
             return cpp.material_count
         return 0
 
+    materialCount = material_count  # Unity PascalCase alias
+
     def get_material(self, slot: int):
         """Get the material at a given slot index."""
         cpp = self._cpp_component
@@ -112,11 +171,21 @@ class MeshRenderer(BuiltinComponent):
             return cpp.get_material(slot)
         return None
 
-    def set_material(self, slot: int, material) -> None:
-        """Set the material at a given slot index by GUID, object, or None."""
+    def set_material(self, slot_or_material, material=None) -> None:
+        """Set a material.  Two calling conventions::
+
+            mr.set_material(0, some_material)   # slot + material
+            mr.set_material(some_material)       # slot 0 shorthand
+
+        Accepts Material wrapper, InxMaterial, GUID string, or None.
+        """
         cpp = self._cpp_component
-        if cpp is not None:
-            cpp.set_material(slot, material)
+        if cpp is None:
+            return
+        if material is None and not isinstance(slot_or_material, int):
+            cpp.set_material(0, _to_native_material(slot_or_material))
+        else:
+            cpp.set_material(slot_or_material, _to_native_material(material))
 
     def get_material_guids(self) -> List[str]:
         """Get all material slot GUIDs as a list."""
@@ -125,11 +194,62 @@ class MeshRenderer(BuiltinComponent):
             return cpp.get_material_guids()
         return []
 
-    def set_materials(self, guids: List[str]) -> None:
-        """Set all material slots from a list of GUIDs."""
+    # ---- Unity Renderer.GetMaterials / GetSharedMaterials ----
+
+    def get_materials(self, result: Optional[list] = None) -> list:
+        """Return all materials as a list.
+
+        If *result* is provided it is cleared and filled in-place
+        (Unity non-alloc pattern); otherwise a new list is returned.
+
+        Matches Unity ``Renderer.GetMaterials``.
+        """
+        mats = self.materials
+        if result is not None:
+            result.clear()
+            result.extend(mats)
+            return result
+        return mats
+
+    GetMaterials = get_materials  # Unity PascalCase alias
+
+    def get_shared_materials(self, result: Optional[list] = None) -> list:
+        """Return all shared materials (equivalent to ``get_materials``).
+
+        Matches Unity ``Renderer.GetSharedMaterials``.
+        """
+        return self.get_materials(result)
+
+    GetSharedMaterials = get_shared_materials  # Unity PascalCase alias
+
+    # ---- Unity Renderer.SetMaterials / SetSharedMaterials ----
+
+    def set_materials(self, materials_list: list) -> None:
+        """Set all material slots from a list.
+
+        Accepts Material wrappers, InxMaterial objects, GUID strings, or None.
+        Matches Unity ``Renderer.SetMaterials``.
+        """
         cpp = self._cpp_component
-        if cpp is not None:
-            cpp.set_materials(guids)
+        if cpp is None:
+            return
+        for i, mat in enumerate(materials_list):
+            native = _to_native_material(mat)
+            if isinstance(native, str):
+                cpp.set_material(i, native)
+            else:
+                cpp.set_material(i, native)
+
+    SetMaterials = set_materials  # Unity PascalCase alias
+
+    def set_shared_materials(self, materials_list: list) -> None:
+        """Alias for ``set_materials`` (Unity compatibility).
+
+        Matches Unity ``Renderer.SetSharedMaterials``.
+        """
+        self.set_materials(materials_list)
+
+    SetSharedMaterials = set_shared_materials  # Unity PascalCase alias
 
     def set_material_slot_count(self, count: int) -> None:
         """Set the number of material slots."""

--- a/python/Infernux/components/script_loader.py
+++ b/python/Infernux/components/script_loader.py
@@ -228,6 +228,9 @@ def load_component_class_from_file(file_path: str, type_name: str = "") -> Optio
         for component_class in components:
             if component_class.__name__ == type_name:
                 return component_class
+        # Class was likely renamed — if exactly one subclass exists, use it.
+        if len(components) == 1:
+            return components[0]
         return None
 
     if len(components) != 1:

--- a/python/Infernux/core/asset_ref.py
+++ b/python/Infernux/core/asset_ref.py
@@ -224,8 +224,10 @@ class MaterialRef(AssetRefBase):
 
     def _do_resolve(self):
         if not self._guid and not self._path_hint:
-            self._cached = None
-            return None
+            # Runtime-created materials (e.g. via Clone/Instantiate) have no
+            # GUID or path.  Keep the cached reference alive instead of
+            # discarding it — there is no asset database entry to re-resolve.
+            return self._cached
         # Primary: load by GUID through AssetManager
         if self._guid:
             try:
@@ -266,6 +268,26 @@ class MaterialRef(AssetRefBase):
                 _log.warning("MaterialRef.resolve by path_hint failed: %s", exc)
         self._cached = None
         return None
+
+    def __bool__(self):
+        """True if the ref points to a valid material (asset or runtime)."""
+        return bool(self._guid) or self._cached is not None
+
+    @property
+    def display_name(self) -> str:
+        if self._path_hint:
+            return os.path.basename(self._path_hint)
+        if self._guid:
+            return f"GUID:{self._guid[:8]}\u2026"
+        # Runtime material — use its name directly
+        mat = self._cached
+        if mat is not None:
+            try:
+                native = getattr(mat, "native", mat)
+                return native.name or "(Runtime Material)"
+            except Exception:
+                pass
+        return "None"
 
     def __getattr__(self, name: str) -> Any:
         """Forward attribute access to the underlying Material."""

--- a/python/Infernux/core/material.py
+++ b/python/Infernux/core/material.py
@@ -582,3 +582,17 @@ class Material:
 
     def __hash__(self):
         return hash(self.guid)
+
+    # ==========================================================================
+    # Clone / Instantiate (Unity-style)
+    # ==========================================================================
+
+    def clone(self) -> "Material":
+        """Create a deep copy of this material (Unity: ``new Material(original)``).
+
+        All properties, shader names, and render state are copied.
+        Texture references remain shared (same as Unity).
+        The clone is a runtime-only instance with no GUID or file path.
+        """
+        cloned_native = self._native.clone()
+        return Material(cloned_native)

--- a/python/Infernux/engine/engine.py
+++ b/python/Infernux/engine/engine.py
@@ -417,6 +417,10 @@ class Engine():
     def set_gui_font(self, font_path, font_size=18):
         self._engine.set_gui_font(_safe_path(font_path), font_size)
 
+    def set_gui_player_mode(self, enabled: bool):
+        """Skip DockSpace/layout overhead in standalone player builds."""
+        self._engine.set_gui_player_mode(bool(enabled))
+
     def get_display_scale(self) -> float:
         """Return the OS display scale factor (e.g. 2.0 for 200% Windows scaling)."""
         return self._engine.get_display_scale()

--- a/python/Infernux/engine/play_mode.py
+++ b/python/Infernux/engine/play_mode.py
@@ -709,6 +709,10 @@ class PlayModeManager(PlayModeSerializationMixin):
             target_type_name = state.get("type_name") or getattr(old_comp, "type_name", type(old_comp).__name__)
             component_class = reloaded_by_name.get(target_type_name)
 
+            # Class was likely renamed — if exactly one subclass exists, use it.
+            if component_class is None and len(reloaded_classes) == 1:
+                component_class = reloaded_classes[0]
+
             if component_class is None:
                 Debug.log_error(
                     f"Failed to reload component '{target_type_name}' from {os.path.basename(script_path_abs)}: "

--- a/python/Infernux/engine/player_bootstrap.py
+++ b/python/Infernux/engine/player_bootstrap.py
@@ -128,6 +128,10 @@ class PlayerBootstrap:
         # renderer would execute both scene and game render graphs every frame.
         self.engine.set_scene_view_visible(False)
 
+        # Skip DockSpace / DockBuilder overhead — the player only registers a
+        # single full-screen renderable, so the editor docking system is waste.
+        self.engine.set_gui_player_mode(True)
+
         self.engine.set_gui_font(_resources.engine_font_path, 15)
 
 

--- a/python/Infernux/engine/ui/project_file_ops.py
+++ b/python/Infernux/engine/ui/project_file_ops.py
@@ -139,6 +139,25 @@ def _iter_asset_move_pairs(old_path: str, new_path: str):
         yield old_path, new_path
 
 
+def _update_build_settings_scene_path(old_path: str, new_path: str):
+    """Replace *old_path* with *new_path* in BuildSettings.json scene list."""
+    try:
+        from .build_settings_panel import load_build_settings, save_build_settings
+        settings = load_build_settings()
+        scenes = settings.get("scenes", [])
+        old_norm = os.path.normcase(os.path.abspath(old_path))
+        changed = False
+        for i, s in enumerate(scenes):
+            if os.path.normcase(os.path.abspath(s)) == old_norm:
+                scenes[i] = os.path.abspath(new_path)
+                changed = True
+        if changed:
+            settings["scenes"] = scenes
+            save_build_settings(settings)
+    except Exception as _exc:
+        Debug.log(f"[BuildSettings] Failed to update scene path: {_exc}")
+
+
 def _notify_asset_moved(old_path: str, new_path: str, asset_database=None):
     from Infernux.core.assets import AssetManager
     from . import asset_inspector
@@ -155,6 +174,10 @@ def _notify_asset_moved(old_path: str, new_path: str, asset_database=None):
     except Exception as _exc:
         Debug.log(f"[Suppressed] {type(_exc).__name__}: {_exc}")
         pass
+
+    # Update BuildSettings.json when a .scene file is renamed/moved
+    if old_path.lower().endswith(".scene"):
+        _update_build_settings_scene_path(old_path, new_path)
 
     asset_inspector.invalidate_asset(old_path)
     asset_inspector.invalidate_asset(new_path)

--- a/python/Infernux/instantiate.py
+++ b/python/Infernux/instantiate.py
@@ -1,0 +1,104 @@
+"""
+Unified Instantiate — Unity-style Object.Instantiate for all asset types.
+
+Usage::
+
+    from Infernux import Instantiate
+
+    # Clone a GameObject (deep copy of hierarchy + components)
+    clone = Instantiate(original_go)
+    clone = Instantiate(original_go, parent=some_parent)
+
+    # Clone a Material (deep copy of all properties)
+    mat_clone = Instantiate(original_material)
+
+    # Clone a Python Material wrapper
+    from Infernux.core import Material
+    mat = Material.create_lit("Gold")
+    mat_clone = Instantiate(mat)
+"""
+
+from __future__ import annotations
+
+from typing import Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+
+
+def Instantiate(original, parent=None):
+    """Clone an object.  Dispatches by type — mirrors Unity's ``Object.Instantiate``.
+
+    Supported types:
+
+    * **GameObject** — deep-copies the hierarchy, all C++ components, and
+      queues Python component restoration.  Optionally reparents under *parent*.
+    * **Material** (Python wrapper) — deep-copies all shader properties,
+      render state, and overrides.  Texture/shader references are shared.
+    * **InxMaterial** (C++ native) — same as Material but returns the raw
+      C++ ``InxMaterial`` object.
+    * **GameObjectRef** / **PrefabRef** — delegates to their ``.instantiate()``
+      method.
+
+    Parameters
+    ----------
+    original : GameObject | Material | InxMaterial | GameObjectRef | PrefabRef
+        The object to clone.
+    parent : GameObject | None
+        (GameObject only) Optional parent for the cloned object.
+
+    Returns
+    -------
+    The cloned object (same wrapper type as *original*), or ``None`` on failure.
+
+    Examples
+    --------
+    >>> clone = Instantiate(cube)
+    >>> mat2 = Instantiate(gold_material)
+    """
+    if original is None:
+        return None
+
+    # ── Python Material wrapper ──────────────────────────────────────────
+    from Infernux.core.material import Material
+    if isinstance(original, Material):
+        return original.clone()
+
+    # ── C++ InxMaterial (raw) ────────────────────────────────────────────
+    from Infernux.lib import InxMaterial
+    if isinstance(original, InxMaterial):
+        return original.clone()
+
+    # ── C++ GameObject ───────────────────────────────────────────────────
+    from Infernux.lib import GameObject
+    if isinstance(original, GameObject):
+        return GameObject.instantiate(original, parent)
+
+    # ── GameObjectRef / PrefabRef (have .instantiate()) ──────────────────
+    if hasattr(original, "instantiate") and callable(original.instantiate):
+        return original.instantiate()
+
+    raise TypeError(
+        f"Instantiate: unsupported type {type(original).__name__!r}. "
+        f"Expected GameObject, Material, InxMaterial, GameObjectRef, or PrefabRef."
+    )
+
+
+def Destroy(obj, delay: float = 0.0):
+    """Destroy a GameObject.  Mirrors Unity's ``Object.Destroy``.
+
+    Parameters
+    ----------
+    obj : GameObject
+        The GameObject to destroy.
+    delay : float
+        Unused (reserved for future delayed-destroy support).
+    """
+    from Infernux.lib import GameObject
+    if isinstance(obj, GameObject):
+        GameObject.destroy(obj)
+    else:
+        raise TypeError(
+            f"Destroy: unsupported type {type(obj).__name__!r}. "
+            f"Expected GameObject."
+        )


### PR DESCRIPTION
## Asset Rename Tracking
- Scene file rename now updates paths in `BuildSettings.json` automatically
- Script class rename fallback: when a `.py` file has exactly one `InxComponent` subclass and the stored `type_name` doesn't match, use that class instead of reporting broken
- Hot-reload (`play_mode.reload_components_from_script`) applies the same single-class fallback for renamed classes

## Lifecycle Dispatch Optimization
- Cache component execution order per-GameObject (invalidated on add/remove/order change)
- Per-object lifecycle receiver flags (`m_hasUpdateReceivers`, `m_hasFixedUpdateReceivers`, `m_hasLateUpdateReceivers`) — skip dispatch entirely when no receivers exist
- `PyComponentProxy` detects Python method overrides at construction time — skip no-op C++→Python round-trips for `fixed_update`/`late_update`
- Coroutine scheduler presence tracked per-proxy to avoid unnecessary ticks

## Renderer & Resource Cleanup
- Resource cleanup for `InxMaterial` and `InxTexture` leak prevention
- Material pipeline manager improvements
- `InxVkCoreModular` resource tracking additions
- Editor UI overhead skipped in player mode
- `MeshRenderer` builtin component improvements
- `instantiate` module additions