### PR TITLE
editor viewport (AMD), scene-scoped transform frame cache, and shader hardening

### DIFF
--- a/cpp/infernux/function/resources/InxMaterial/InxMaterial.cpp
+++ b/cpp/infernux/function/resources/InxMaterial/InxMaterial.cpp
@@ -957,11 +957,13 @@ std::shared_ptr<InxMaterial> InxMaterial::CreateGridMaterial()
     state.depthTestEnable = true;
     state.depthWriteEnable = false; // Transparent — don't write depth
     state.depthCompareOp = VK_COMPARE_OP_LESS_OR_EQUAL;
-    // Depth bias pushes the grid slightly behind coplanar geometry to avoid z-fighting
+    // Keep only a tiny constant bias. Slope-scaled bias explodes at grazing
+    // angles when the editor camera is close to the XZ plane, which produces
+    // driver-dependent stair-step artifacts on older AMD GPUs.
     state.depthBiasEnable = true;
-    state.depthBiasConstantFactor = 2.0f;
-    state.depthBiasSlopeFactor = 2.0f;
-    state.depthBiasClamp = 0.01f;
+    state.depthBiasConstantFactor = 1.0f;
+    state.depthBiasSlopeFactor = 0.0f;
+    state.depthBiasClamp = 0.0f;
     state.blendEnable = true;
     state.srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
     state.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;

--- a/cpp/infernux/function/scene/SceneManager.cpp
+++ b/cpp/infernux/function/scene/SceneManager.cpp
@@ -163,9 +163,10 @@ void SceneManager::Update(float deltaTime)
 {
     m_lastFrameProfile = {};
 
-    // Always update editor camera (for editor viewport navigation)
+    // Editor camera navigation is advanced by Infernux::ProcessSceneViewInput,
+    // where the current Scene View hover/capture state is known. Updating it
+    // here would apply stale key state or move twice in one frame.
     auto t0 = ProfileClock::now();
-    m_editorCamera.Update(deltaTime);
     m_lastFrameProfile.editorCameraMs += ProfileMsSince(t0);
 
     if (!m_isPlaying && m_activeScene) {

--- a/cpp/infernux/function/scene/Transform.cpp
+++ b/cpp/infernux/function/scene/Transform.cpp
@@ -45,7 +45,7 @@ glm::vec3 Transform::GetWorldDirection(const glm::vec3 &localAxis) const
 glm::vec3 Transform::GetWorldPosition() const
 {
     auto &store = TransformECSStore::Instance();
-    if (store.IsFrameCacheActive()) {
+    if (store.IsFrameCacheActiveFor(m_ecsHandle)) {
         return store.GetCachedWorldPosition(m_ecsHandle.index);
     }
 
@@ -61,7 +61,7 @@ glm::vec3 Transform::GetWorldPosition() const
 void Transform::SetWorldPosition(const glm::vec3 &worldPos)
 {
     auto &store = TransformECSStore::Instance();
-    if (store.IsFrameCacheActive()) {
+    if (store.IsFrameCacheActiveFor(m_ecsHandle)) {
         store.SetCachedWorldPosition(m_ecsHandle.index, worldPos);
         return;
     }
@@ -116,7 +116,7 @@ void Transform::InvalidateWorldMatrix(bool clearWorldEulerExact) const
 glm::quat Transform::GetWorldRotation() const
 {
     auto &store = TransformECSStore::Instance();
-    if (store.IsFrameCacheActive()) {
+    if (store.IsFrameCacheActiveFor(m_ecsHandle)) {
         return store.GetCachedWorldRotation(m_ecsHandle.index);
     }
 
@@ -131,7 +131,7 @@ glm::quat Transform::GetWorldRotation() const
 void Transform::SetWorldRotation(const glm::quat &worldRot)
 {
     auto &store = TransformECSStore::Instance();
-    if (store.IsFrameCacheActive()) {
+    if (store.IsFrameCacheActiveFor(m_ecsHandle)) {
         store.SetCachedWorldRotation(m_ecsHandle.index, glm::normalize(worldRot));
         return;
     }
@@ -188,7 +188,7 @@ void Transform::SetWorldEulerAngles(const glm::vec3 &euler)
     glm::quat worldRot = EulerYXZToQuat(euler);
 
     auto &store = TransformECSStore::Instance();
-    if (store.IsFrameCacheActive()) {
+    if (store.IsFrameCacheActiveFor(m_ecsHandle)) {
         store.SetCachedWorldRotation(m_ecsHandle.index, worldRot);
         return;
     }

--- a/cpp/infernux/function/scene/TransformECSStore.cpp
+++ b/cpp/infernux/function/scene/TransformECSStore.cpp
@@ -2,12 +2,50 @@
 #include "GameObject.h"
 #include "Scene.h"
 #include "Transform.h"
+#include <cmath>
 #include <cstring>
+#include <glm/gtc/constants.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtc/quaternion.hpp>
 
 namespace infernux
 {
+
+namespace
+{
+glm::quat EulerYXZToQuat(const glm::vec3 &eulerDeg)
+{
+    glm::vec3 r = glm::radians(eulerDeg);
+    float cx = std::cos(r.x * 0.5f), sx = std::sin(r.x * 0.5f);
+    float cy = std::cos(r.y * 0.5f), sy = std::sin(r.y * 0.5f);
+    float cz = std::cos(r.z * 0.5f), sz = std::sin(r.z * 0.5f);
+
+    glm::quat q;
+    q.w = cy * cx * cz + sy * sx * sz;
+    q.x = cy * sx * cz + sy * cx * sz;
+    q.y = sy * cx * cz - cy * sx * sz;
+    q.z = cy * cx * sz - sy * sx * cz;
+    return q;
+}
+
+glm::vec3 QuatToEulerYXZ(const glm::quat &rotation)
+{
+    glm::quat q = glm::normalize(rotation);
+    float sinX = 2.0f * (q.w * q.x - q.y * q.z);
+
+    float x, y, z;
+    if (std::abs(sinX) < 0.9999f) {
+        x = std::asin(sinX);
+        y = std::atan2(2.0f * (q.x * q.z + q.w * q.y), 1.0f - 2.0f * (q.x * q.x + q.y * q.y));
+        z = std::atan2(2.0f * (q.x * q.y + q.w * q.z), 1.0f - 2.0f * (q.x * q.x + q.z * q.z));
+    } else {
+        x = std::copysign(glm::half_pi<float>(), sinX);
+        y = std::atan2(-(2.0f * (q.x * q.z - q.w * q.y)), 1.0f - 2.0f * (q.y * q.y + q.z * q.z));
+        z = 0.0f;
+    }
+    return glm::degrees(glm::vec3(x, y, z));
+}
+} // namespace
 
 TransformECSStore &TransformECSStore::Instance()
 {
@@ -44,6 +82,7 @@ TransformECSStore::Handle TransformECSStore::Allocate(Transform *owner)
         // Keep frame cache arrays in sync with capacity.
         m_fcWorldPositions.emplace_back(0.0f, 0.0f, 0.0f);
         m_fcWorldRotations.emplace_back(1.0f, 0.0f, 0.0f, 0.0f);
+        m_fcRotationValid.push_back(0);
         m_fcDirty.push_back(0);
     }
 
@@ -59,6 +98,7 @@ TransformECSStore::Handle TransformECSStore::Allocate(Transform *owner)
     m_cachedWorldMatrices[index] = glm::mat4(1.0f);
     m_worldMatrixDirty[index] = 1;
     m_anyWorldMatrixDirty = true;
+    m_fcRotationValid[index] = 0;
     m_owners[index] = owner;
 
     ++m_aliveCount;
@@ -73,6 +113,7 @@ void TransformECSStore::Release(Handle handle)
     uint32_t idx = handle.index;
     m_owners[idx] = nullptr;
     m_alive[idx] = 0;
+    m_fcRotationValid[idx] = 0;
     ++m_generations[idx];
     m_nextFree[idx] = m_freeListHead;
     m_freeListHead = idx;
@@ -113,6 +154,7 @@ void TransformECSStore::Reserve(size_t capacity)
     m_nextFree.reserve(capacity);
     m_fcWorldPositions.reserve(capacity);
     m_fcWorldRotations.reserve(capacity);
+    m_fcRotationValid.reserve(capacity);
     m_fcDirty.reserve(capacity);
 }
 
@@ -147,6 +189,7 @@ void TransformECSStore::SetSnapshot(Handle h, const TransformECSData &d)
     m_dirty[i] = d.dirty ? 1 : 0;
     m_cachedWorldMatrices[i] = d.cachedWorldMatrix;
     m_worldMatrixDirty[i] = d.worldMatrixDirty ? 1 : 0;
+    m_fcRotationValid[i] = 0;
     if (d.worldMatrixDirty)
         m_anyWorldMatrixDirty = true;
     m_owners[i] = d.owner;
@@ -174,7 +217,7 @@ void TransformECSStore::InvalidateSubtree(Transform *root, bool clearWorldEulerE
     }
     if (clearWorldEulerExact) {
         self.m_worldEulerExact[idx] = 0;
-        self.m_anyRotationDirtied = true;
+        self.m_fcRotationValid[idx] = 0;
     }
 
     GameObject *go = root->GetGameObject();
@@ -213,7 +256,38 @@ void TransformECSStore::SyncSceneWorldMatrices(Scene *scene)
         SyncObjectWorldMatrices(root.get());
     }
 
-    m_anyWorldMatrixDirty = false;
+    m_anyWorldMatrixDirty = HasAnyDirtyWorldMatrices();
+}
+
+bool TransformECSStore::IsFrameCacheActiveFor(Handle h) const
+{
+    if (!m_frameCacheActive || !IsValid(h)) {
+        return false;
+    }
+
+    return IsSlotInScene(h.index, m_fcScene);
+}
+
+bool TransformECSStore::IsSlotInScene(size_t index, const Scene *scene) const
+{
+    if (!scene || index >= m_owners.size() || !m_alive[index]) {
+        return false;
+    }
+
+    Transform *owner = m_owners[index];
+    GameObject *go = owner ? owner->GetGameObject() : nullptr;
+    return go && go->GetScene() == scene;
+}
+
+bool TransformECSStore::HasAnyDirtyWorldMatrices() const
+{
+    const size_t count = m_worldMatrixDirty.size();
+    for (size_t i = 0; i < count; ++i) {
+        if (m_alive[i] && m_worldMatrixDirty[i]) {
+            return true;
+        }
+    }
+    return false;
 }
 
 void TransformECSStore::SyncObjectWorldMatrices(GameObject *obj)
@@ -334,13 +408,13 @@ void TransformECSStore::ScatterLocalRotations(Transform *const *transforms, cons
         uint32_t idx = h.index;
         glm::quat q(in[i * 4 + 3], in[i * 4], in[i * 4 + 1], in[i * 4 + 2]); // glm: (w,x,y,z)
         m_localRotations[idx] = q;
-        m_localEulerAngles[idx] = glm::degrees(glm::eulerAngles(q));
+        m_localEulerAngles[idx] = QuatToEulerYXZ(q);
         m_hasCachedWorldEulerAngles[idx] = 0;
+        m_fcRotationValid[idx] = 0;
         m_dirty[idx] = 1;
         m_worldMatrixDirty[idx] = 1;
     }
     m_anyWorldMatrixDirty = true;
-    m_anyRotationDirtied = true;
     for (size_t i = 0; i < count; ++i) {
         GameObject *go = transforms[i]->GetGameObject();
         if (go && go->GetChildCount() > 0) {
@@ -367,15 +441,13 @@ void TransformECSStore::ScatterLocalEulerAngles(Transform *const *transforms, co
         uint32_t idx = h.index;
         glm::vec3 euler(in[i * 3], in[i * 3 + 1], in[i * 3 + 2]);
         m_localEulerAngles[idx] = euler;
-        // Recompute quaternion from euler (YXZ convention).
-        glm::vec3 rad = glm::radians(euler);
-        m_localRotations[idx] = glm::quat(rad);
+        m_localRotations[idx] = EulerYXZToQuat(euler);
         m_hasCachedWorldEulerAngles[idx] = 0;
+        m_fcRotationValid[idx] = 0;
         m_dirty[idx] = 1;
         m_worldMatrixDirty[idx] = 1;
     }
     m_anyWorldMatrixDirty = true;
-    m_anyRotationDirtied = true;
     for (size_t i = 0; i < count; ++i) {
         GameObject *go = transforms[i]->GetGameObject();
         if (go && go->GetChildCount() > 0) {
@@ -475,29 +547,23 @@ void TransformECSStore::BeginFrameCache(Scene *scene)
     if (m_fcWorldPositions.size() < cap) {
         m_fcWorldPositions.resize(cap);
         m_fcWorldRotations.resize(cap);
+        m_fcRotationValid.resize(cap, 0);
         m_fcDirty.resize(cap, 0);
     }
 
-    // Extract world position (column 3) and rotation from cached world matrices.
-    if (m_anyRotationDirtied) {
-        // Full extraction: position + rotation (expensive quat_cast).
-        for (size_t i = 0; i < cap; ++i) {
-            if (!m_alive[i]) {
-                continue;
-            }
-            const glm::mat4 &wm = m_cachedWorldMatrices[i];
-            m_fcWorldPositions[i] = glm::vec3(wm[3]);
-            m_fcWorldRotations[i] = glm::quat_cast(glm::mat3(wm));
+    // Extract scene-scoped world position and lazily refresh rotation.
+    // Tool objects such as the editor camera are not owned by the active scene
+    // and must not read stale matrices through this per-scene frame cache.
+    for (size_t i = 0; i < cap; ++i) {
+        if (!IsSlotInScene(i, scene)) {
+            continue;
         }
-        m_anyRotationDirtied = false;
-    } else {
-        // Fast path: only extract positions (cheap vec3 copy).
-        // Rotations haven't changed since last snapshot.
-        for (size_t i = 0; i < cap; ++i) {
-            if (!m_alive[i]) {
-                continue;
-            }
-            m_fcWorldPositions[i] = glm::vec3(m_cachedWorldMatrices[i][3]);
+
+        const glm::mat4 &wm = m_cachedWorldMatrices[i];
+        m_fcWorldPositions[i] = glm::vec3(wm[3]);
+        if (!m_fcRotationValid[i]) {
+            m_fcWorldRotations[i] = glm::quat_cast(glm::mat3(wm));
+            m_fcRotationValid[i] = 1;
         }
     }
     std::memset(m_fcDirty.data(), 0, cap);
@@ -518,7 +584,7 @@ void TransformECSStore::EndFrameCache()
     const size_t cap = m_fcDirty.size();
     for (size_t i = 0; i < cap; ++i) {
         const uint8_t d = m_fcDirty[i];
-        if (d == 0 || !m_alive[i]) {
+        if (d == 0 || !IsSlotInScene(i, m_fcScene)) {
             continue;
         }
 
@@ -550,8 +616,9 @@ void TransformECSStore::EndFrameCache()
             } else {
                 m_localRotations[i] = glm::inverse(parent->GetWorldRotation()) * m_fcWorldRotations[i];
             }
-            m_localEulerAngles[i] = glm::degrees(glm::eulerAngles(m_localRotations[i]));
+            m_localEulerAngles[i] = QuatToEulerYXZ(m_localRotations[i]);
             m_hasCachedWorldEulerAngles[i] = 0;
+            m_fcRotationValid[i] = 1;
             m_dirty[i] = 1;
             m_worldMatrixDirty[i] = 1;
         }
@@ -596,8 +663,8 @@ void TransformECSStore::SetCachedWorldPosition(uint32_t slotIndex, const glm::ve
 void TransformECSStore::SetCachedWorldRotation(uint32_t slotIndex, const glm::quat &q)
 {
     m_fcWorldRotations[slotIndex] = q;
+    m_fcRotationValid[slotIndex] = 1;
     m_fcDirty[slotIndex] |= 0x02;
-    m_anyRotationDirtied = true;
 }
 
 void TransformECSStore::SetCachedLocalPosition(uint32_t slotIndex, const glm::vec3 &v)
@@ -619,24 +686,23 @@ void TransformECSStore::SetCachedLocalScale(uint32_t slotIndex, const glm::vec3 
 void TransformECSStore::SetCachedLocalRotation(uint32_t slotIndex, const glm::quat &q)
 {
     m_localRotations[slotIndex] = q;
-    m_localEulerAngles[slotIndex] = glm::degrees(glm::eulerAngles(q));
+    m_localEulerAngles[slotIndex] = QuatToEulerYXZ(q);
     m_hasCachedWorldEulerAngles[slotIndex] = 0;
+    m_fcRotationValid[slotIndex] = 0;
     m_fcDirty[slotIndex] |= 0x10;
     m_worldMatrixDirty[slotIndex] = 1;
     m_anyWorldMatrixDirty = true;
-    m_anyRotationDirtied = true;
 }
 
 void TransformECSStore::SetCachedLocalEulerAngles(uint32_t slotIndex, const glm::vec3 &v)
 {
     m_localEulerAngles[slotIndex] = v;
-    glm::vec3 rad = glm::radians(v);
-    m_localRotations[slotIndex] = glm::quat(rad);
+    m_localRotations[slotIndex] = EulerYXZToQuat(v);
     m_hasCachedWorldEulerAngles[slotIndex] = 0;
+    m_fcRotationValid[slotIndex] = 0;
     m_fcDirty[slotIndex] |= 0x20;
     m_worldMatrixDirty[slotIndex] = 1;
     m_anyWorldMatrixDirty = true;
-    m_anyRotationDirtied = true;
 }
 
 } // namespace infernux

--- a/cpp/infernux/function/scene/TransformECSStore.h
+++ b/cpp/infernux/function/scene/TransformECSStore.h
@@ -305,9 +305,10 @@ class TransformECSStore
     {
         return m_frameCacheActive;
     }
+    [[nodiscard]] bool IsFrameCacheActiveFor(Handle h) const;
 
     // Cached world-space read (O(1) array index).  Caller must check
-    // IsFrameCacheActive() before calling.
+    // IsFrameCacheActiveFor() before calling.
     [[nodiscard]] glm::vec3 GetCachedWorldPosition(uint32_t slotIndex) const
     {
         return m_fcWorldPositions[slotIndex];
@@ -334,6 +335,8 @@ class TransformECSStore
   private:
     TransformECSStore() = default;
 
+    [[nodiscard]] bool IsSlotInScene(size_t index, const Scene *scene) const;
+    [[nodiscard]] bool HasAnyDirtyWorldMatrices() const;
     void SyncObjectWorldMatrices(GameObject *obj);
 
     // ── SoA arrays (all the same length == Capacity()) ───────────────
@@ -351,10 +354,6 @@ class TransformECSStore
 
     // ── Global dirty flag for fast SyncSceneWorldMatrices skip ───────
     bool m_anyWorldMatrixDirty = false;
-    // Set when any rotation-affecting setter is called; cleared by BeginFrameCache.
-    // When false, BeginFrameCache skips the expensive quat_cast extraction.
-    bool m_anyRotationDirtied = true;
-
     // ── Global transform change serial (for physics dirty skip) ──────
     uint64_t m_globalTransformSerial = 0;
 
@@ -368,6 +367,7 @@ class TransformECSStore
     // ── Frame Cache arrays (same length as Capacity()) ───────────────
     std::vector<glm::vec3> m_fcWorldPositions;
     std::vector<glm::quat> m_fcWorldRotations;
+    std::vector<uint8_t> m_fcRotationValid;
     // Dirty flags: bit 0 = world position dirty, bit 1 = world rotation dirty,
     // bit 2 = local position dirty, bit 3 = local scale dirty,
     // bit 4 = local rotation dirty, bit 5 = local euler dirty.

--- a/python/Infernux/resources/shaders/grid.frag
+++ b/python/Infernux/resources/shaders/grid.frag
@@ -16,6 +16,10 @@ layout(std140, binding = 0) uniform UniformBufferObject {
 layout(location = 0) in vec3 fragWorldPos;
 layout(location = 0) out vec4 outColor;
 
+vec2 safeFwidth(vec2 value) {
+    return max(fwidth(value), vec2(1e-4));
+}
+
 void main() {
     // Extract camera world position: pos = -(R^T * t) using view matrix orthogonality
     vec3 cameraPos = -(transpose(mat3(ubo.view)) * ubo.view[3].xyz);
@@ -23,7 +27,7 @@ void main() {
     vec2 coord = fragWorldPos.xz;
 
     // ---- Minor grid lines (every 1 unit) ----
-    vec2 dMinor = fwidth(coord);
+    vec2 dMinor = safeFwidth(coord);
     vec2 gridMinor = abs(fract(coord - 0.5) - 0.5);
     vec2 lineMinor = gridMinor / dMinor;
     float minor = 1.0 - min(min(lineMinor.x, lineMinor.y), 1.0);
@@ -34,7 +38,7 @@ void main() {
 
     // ---- Major grid lines (every 10 units) ----
     vec2 coordMajor = coord / 10.0;
-    vec2 dMajor = fwidth(coordMajor);
+    vec2 dMajor = safeFwidth(coordMajor);
     vec2 gridMajor = abs(fract(coordMajor - 0.5) - 0.5);
     vec2 lineMajor = gridMajor / dMajor;
     float major = 1.0 - min(min(lineMajor.x, lineMajor.y), 1.0);

--- a/python/Infernux/resources/shaders/lib/uv.glsl
+++ b/python/Infernux/resources/shaders/lib/uv.glsl
@@ -88,19 +88,22 @@ vec2 radialShearUV(vec2 uv, vec2 center, float strengthX, float strengthY, vec2 
 // Simple parallax offset  (Unity: Parallax Offset)
 vec2 parallaxOffset(vec2 uv, vec3 viewDirTangent, float heightMap, float scale) {
     float h = heightMap * scale - scale * 0.5;
-    return uv + viewDirTangent.xy / viewDirTangent.z * h;
+    float viewZ = (viewDirTangent.z < 0.0 ? -1.0 : 1.0) * max(abs(viewDirTangent.z), 1e-4);
+    return uv + viewDirTangent.xy / viewZ * h;
 }
 
 // Parallax Occlusion Mapping  (Unity: Parallax Occlusion Mapping)
 vec2 parallaxOcclusionMapping(sampler2D heightTex, vec2 uv, vec3 viewDirTangent,
                                float heightScale, int numLayers) {
-    float layerDepth = 1.0 / float(numLayers);
+    int layerCount = max(numLayers, 1);
+    float layerDepth = 1.0 / float(layerCount);
     float currentLayerDepth = 0.0;
-    vec2 deltaUV = viewDirTangent.xy / viewDirTangent.z * heightScale / float(numLayers);
+    float viewZ = (viewDirTangent.z < 0.0 ? -1.0 : 1.0) * max(abs(viewDirTangent.z), 1e-4);
+    vec2 deltaUV = viewDirTangent.xy / viewZ * heightScale / float(layerCount);
     vec2 currentUV = uv;
     float currentHeight = texture(heightTex, currentUV).r;
 
-    for (int i = 0; i < numLayers; ++i) {
+    for (int i = 0; i < layerCount; ++i) {
         if (currentLayerDepth >= currentHeight) break;
         currentUV -= deltaUV;
         currentHeight = texture(heightTex, currentUV).r;
@@ -110,7 +113,9 @@ vec2 parallaxOcclusionMapping(sampler2D heightTex, vec2 uv, vec3 viewDirTangent,
     vec2 prevUV = currentUV + deltaUV;
     float afterDepth = currentHeight - currentLayerDepth;
     float beforeDepth = texture(heightTex, prevUV).r - currentLayerDepth + layerDepth;
-    float weight = afterDepth / (afterDepth - beforeDepth);
+    float denom = afterDepth - beforeDepth;
+    denom = (denom < 0.0 ? -1.0 : 1.0) * max(abs(denom), 1e-4);
+    float weight = afterDepth / denom;
     return mix(currentUV, prevUV, weight);
 }
 
@@ -121,7 +126,7 @@ vec2 parallaxOcclusionMapping(sampler2D heightTex, vec2 uv, vec3 viewDirTangent,
 // Triplanar blending weights  (Unity: Triplanar — weight computation)
 vec3 triplanarWeights(vec3 worldNormal, float sharpness) {
     vec3 w = pow(abs(worldNormal), vec3(sharpness));
-    return w / (w.x + w.y + w.z);
+    return w / max(w.x + w.y + w.z, 1e-5);
 }
 
 // Triplanar sampling  (Unity: Triplanar)

--- a/python/Infernux/resources/shaders/lighting.glsl
+++ b/python/Infernux/resources/shaders/lighting.glsl
@@ -263,13 +263,15 @@ vec3 calculateAllLighting(vec3 worldPos, vec3 N, vec3 V,
         PointLightData light = lighting.pointLights[i];
         vec3  lightVec = light.position.xyz - worldPos;
         float distance = length(lightVec);
-        vec3  L           = normalize(lightVec);
-        float attenuation = calculateAttenuation(light.attenuation.xyz, distance);
-        if (attenuation > 0.001) {
-            vec3 radiance = light.color.rgb * light.color.w * attenuation;
-            Lo += evaluatePBRLight(N, V, L, radiance, albedo, metallic,
-                                   roughness, perceptualRoughness,
-                                   F0, f90, energyCompensation);
+        if (distance > 1e-5) {
+            vec3  L = lightVec / distance;
+            float attenuation = calculateAttenuation(light.attenuation.xyz, distance);
+            if (attenuation > 0.001) {
+                vec3 radiance = light.color.rgb * light.color.w * attenuation;
+                Lo += evaluatePBRLight(N, V, L, radiance, albedo, metallic,
+                                       roughness, perceptualRoughness,
+                                       F0, f90, energyCompensation);
+            }
         }
     }
 
@@ -278,16 +280,18 @@ vec3 calculateAllLighting(vec3 worldPos, vec3 N, vec3 V,
         SpotLightData light = lighting.spotLights[i];
         vec3  lightVec = light.position.xyz - worldPos;
         float distance = length(lightVec);
-        vec3 L = normalize(lightVec);
-        float spotFalloff = calculateSpotFalloff(L, light.direction.xyz,
-                                                  light.spotParams.x, light.spotParams.y);
-        if (spotFalloff > 0.0) {
-            float attenuation = calculateAttenuation(light.attenuation.xyz, distance);
-            if (attenuation > 0.001) {
-                vec3 radiance = light.color.rgb * light.color.w * attenuation * spotFalloff;
-                Lo += evaluatePBRLight(N, V, L, radiance, albedo, metallic,
-                                       roughness, perceptualRoughness,
-                                       F0, f90, energyCompensation);
+        if (distance > 1e-5) {
+            vec3 L = lightVec / distance;
+            float spotFalloff = calculateSpotFalloff(L, light.direction.xyz,
+                                                      light.spotParams.x, light.spotParams.y);
+            if (spotFalloff > 0.0) {
+                float attenuation = calculateAttenuation(light.attenuation.xyz, distance);
+                if (attenuation > 0.001) {
+                    vec3 radiance = light.color.rgb * light.color.w * attenuation * spotFalloff;
+                    Lo += evaluatePBRLight(N, V, L, radiance, albedo, metallic,
+                                           roughness, perceptualRoughness,
+                                           F0, f90, energyCompensation);
+                }
             }
         }
     }

--- a/python/Infernux/resources/shaders/pbr.glsl
+++ b/python/Infernux/resources/shaders/pbr.glsl
@@ -139,7 +139,7 @@ float ComputeSpecularOcclusion(float NdotV, float ao, float perceptualRoughness)
 // Guarantees smooth falloff to zero at range boundary.
 // attenParams.x = range (yz unused)
 float calculateAttenuation(vec3 attenParams, float distance) {
-    float range = attenParams.x;
+    float range = max(attenParams.x, 1e-4);
     float d2 = distance * distance;
     float r2 = range * range;
     float ratio2 = d2 / r2;
@@ -161,8 +161,9 @@ float GeometricSpecularAA(vec3 worldNormal, float roughness) {
 
 // Spotlight cone falloff
 float calculateSpotFalloff(vec3 lightDir, vec3 spotDir, float innerAngleCos, float outerAngleCos) {
-    float theta   = dot(lightDir, normalize(-spotDir));
-    float epsilon = innerAngleCos - outerAngleCos;
+    float spotLen2 = max(dot(spotDir, spotDir), 1e-8);
+    float theta   = dot(lightDir, -spotDir * inversesqrt(spotLen2));
+    float epsilon = max(innerAngleCos - outerAngleCos, 1e-4);
     return clamp((theta - outerAngleCos) / epsilon, 0.0, 1.0);
 }
 
@@ -182,7 +183,9 @@ vec3 evaluatePBRLight(vec3 N, vec3 V, vec3 L, vec3 lightRadiance,
                       vec3 albedo, float metallic,
                       float roughness, float perceptualRoughness,
                       vec3 F0, float f90, vec3 energyCompensation) {
-    vec3  H     = normalize(V + L);
+    vec3  halfVec = V + L;
+    float halfLen2 = dot(halfVec, halfVec);
+    vec3  H     = (halfLen2 > 1e-8) ? halfVec * inversesqrt(halfLen2) : N;
     float NdotL = max(dot(N, L), 0.0);
     float NdotV = max(dot(N, V), 0.0);
     float NdotH = max(dot(N, H), 0.0);


### PR DESCRIPTION
## Summary

This batch addresses **editor viewport** issues seen on some AMD (and similar) hardware, and fixes misuse of a **global Transform frame cache** for objects that are not in the active scene (e.g. the editor camera) by scoping the cache to scene-owned transform slots. Several GLSL paths were also hardened against divide-by-(near)-zero. For the grid, severe shimmer / “jaggies” when the camera is close to the XZ plane did not respond to `fwidth` clamping alone; the primary driver was treated as **slope-scaled depth bias** on a large, shallow-view plane combined with per-GPU depth quantization, so the grid material disables the slope term and uses a conservative constant offset.

## What changed

- **Transform / ECS**
  - `TransformECSStore`: frame cache now applies **only to slots owned by the current `Scene`**. Added `IsFrameCacheActiveFor`, `IsSlotInScene`, full-sweep dirty world-matrix checks, etc., so out-of-scene objects (e.g. editor camera) do not read stale cache or get incorrect write-back.
  - `Transform`: `Get/SetWorld*` use the frame-cache fast path only when the cache is active **for that handle**.
  - Unified **intrinsic YXZ Euler** and quaternion conversion with `Transform` conventions in cache and batch paths (`EulerYXZToQuat` / `QuatToEulerYXZ`), instead of `glm::eulerAngles` and ad hoc conversions that can disagree with the engine.
  - Per-slot `m_fcRotationValid` (and related logic) tracks whether cached rotation is trustworthy; removed an inaccurate global “rotation-only dirty” shortcut.
- **Editor camera: single update source**
  - `SceneManager::Update` (and the equivalent path on the render side) **no longer** calls `m_editorCamera.Update(deltaTime)`. `Infernux::ProcessSceneViewInput` is the single driver to avoid double updates and torn state.
- **Grid and general shaders**
  - `InxMaterial::CreateGridMaterial`: **disable `depthBiasSlopeFactor` (and the previous heavy clamp)**, keep a modest constant depth bias to reduce z-fighting with the ground while reducing per-pixel depth instability at grazing angles (often misread as severe aliasing).
  - `grid.frag`: lower bound on `fwidth` (complements the depth-bias fix; not the only root cause).
  - `uv.glsl` / `pbr.glsl` / `lighting.glsl`: guards on denominators and normalization in parallax, attenuation, half-vector, etc.

## Verification

- [x] Built the affected targets
- [x] Ran the relevant tests or static validation
- [ ] Updated docs if behavior or public APIs changed

**Suggested manual checks (especially on RX / integrated):**

- With the **scene view close to the XZ plane**, pan/rotate: the grid should not show strong shimmer or stripe-like “jaggies”.
- In edit mode, **WASD / QE / mouse** orbit: Y should not lock; A/D strafe should match expected left/right (compare with a known-good NVIDIA run).
- Scenes with transform batching and play/edit toggles: no odd jitter or one-frame-stale rotation.

## Notes for reviewers

- **Behavioral change:** code that **implicitly relied** on `EditorCameraController::Update` being called from `SceneManager::Update` every frame must be updated to rely on the input pipeline or an explicit single call site. The intended model is **input as the single timing source** for the editor camera.
- **Frame cache:** any new object that **uses `Transform` but is not in a `Scene`** must not assume a global frame cache. Keep respecting `IsFrameCacheActiveFor`, or extend ownership explicitly if you add multi-scene parallel editing later.
- **Grid depth:** if z-fighting against specific geometry returns, tune **`depthBiasConstantFactor`**; avoid reintroducing a large slope term without measuring artifacts.
- **Risk / perf:** `TransformECSStore` and `Transform` are hot paths. After merge, a quick **perf baseline** on target hardware is useful (caching is now scene-scoped; cost should be bounded and often better).

## Suggested short PR / release title

**Editor: AMD viewport grid & camera; scene-scoped transform frame cache & shader safety**
