### PR TITLE
017/fix chinese path

### DIFF
--- a/cpp/infernux/Infernux.cpp
+++ b/cpp/infernux/Infernux.cpp
@@ -467,7 +467,7 @@ bool BuildPrefabPreviewMesh(const std::string &prefabFilePath, std::shared_ptr<I
     if (aggregate.vertices.empty() || aggregate.indices.empty() || aggregate.subMeshes.empty())
         return false;
 
-    auto mesh = std::make_shared<InxMesh>(ToFsPath(prefabFilePath).stem().string());
+    auto mesh = std::make_shared<InxMesh>(FromFsPath(ToFsPath(prefabFilePath).stem()));
     mesh->SetFilePath(prefabFilePath);
     mesh->SetData(std::move(aggregate.vertices), std::move(aggregate.indices), std::move(aggregate.subMeshes));
 
@@ -498,7 +498,7 @@ std::vector<std::shared_ptr<InxMaterial>> BuildDefaultPreviewMaterialsForMesh(co
 
 bool IsPrefabPreviewPath(const std::string &filePath)
 {
-    std::string ext = ToFsPath(filePath).extension().string();
+    std::string ext = FromFsPath(ToFsPath(filePath).extension());
     std::transform(ext.begin(), ext.end(), ext.begin(),
                    [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
     return ext == ".prefab";
@@ -2014,7 +2014,7 @@ void Infernux::LoadAndRegisterShaders(const std::string &dir, bool recursive)
         if (!entry.is_regular_file())
             return;
         fs::path file = entry.path();
-        std::string ext = file.extension().string();
+        std::string ext = FromFsPath(file.extension());
 
         if (ext != ".vert" && ext != ".frag")
             return;
@@ -2166,7 +2166,7 @@ std::string Infernux::ReloadShader(const std::string &shaderPath)
     }
 
     std::filesystem::path path = ToFsPath(shaderPath);
-    std::string ext = path.extension().string();
+    std::string ext = FromFsPath(path.extension());
 
     if (ext != ".vert" && ext != ".frag") {
         INXLOG_ERROR("Infernux::ReloadShader: unsupported shader extension: ", ext);

--- a/cpp/infernux/function/audio/AudioClip.cpp
+++ b/cpp/infernux/function/audio/AudioClip.cpp
@@ -35,7 +35,7 @@ bool DecodeWaveFile(const std::string &filePath, SDL_AudioSpec &spec, std::vecto
 
 bool DecodeAudioFile(const std::string &filePath, SDL_AudioSpec &spec, std::vector<uint8_t> &data)
 {
-    std::string extension = ToFsPath(filePath).extension().string();
+    std::string extension = FromFsPath(ToFsPath(filePath).extension());
     std::transform(extension.begin(), extension.end(), extension.begin(), ::tolower);
 
     if (extension == ".wav") {

--- a/cpp/infernux/function/audio/AudioClipLoader.cpp
+++ b/cpp/infernux/function/audio/AudioClipLoader.cpp
@@ -99,13 +99,13 @@ void AudioClipLoader::CreateMeta(const char *content, size_t contentSize, const 
 {
     metaData.Init(content, contentSize, filePath, ResourceType::Audio);
 
-    std::filesystem::path path(filePath);
-    std::string resourceName = path.stem().string();
+    std::filesystem::path path = ToFsPath(filePath);
+    std::string resourceName = FromFsPath(path.stem());
 
     metaData.AddMetadata("resource_name", resourceName);
     metaData.AddMetadata("file_size", static_cast<int>(contentSize));
     metaData.AddMetadata("file_type", std::string("audio"));
-    metaData.AddMetadata("extension", path.extension().string());
+    metaData.AddMetadata("extension", FromFsPath(path.extension()));
 }
 
 } // namespace infernux

--- a/cpp/infernux/function/editor/ProjectPanel.cpp
+++ b/cpp/infernux/function/editor/ProjectPanel.cpp
@@ -366,11 +366,14 @@ std::string ProjectPanel::NormalizePath(const std::string &path)
     auto canonical = fs::weakly_canonical(fs::u8path(path), ec);
     if (ec)
         return path;
-    auto str = canonical.string();
-    // Lowercase on Windows for case-insensitive comparison
+    std::string str = infernux::FromFsPath(canonical);
+    // Case-fold ASCII letters only — UTF-8 multibyte sequences must stay intact.
 #ifdef _WIN32
-    for (auto &c : str)
-        c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    for (auto &c : str) {
+        unsigned char uc = static_cast<unsigned char>(c);
+        if (uc >= 'A' && uc <= 'Z')
+            c = static_cast<char>(uc + 32);
+    }
 #endif
     return str;
 }
@@ -437,10 +440,10 @@ void ProjectPanel::SetRootPath(const std::string &path)
 {
     m_rootPath = path;
     InvalidateDirCache();
-    auto assetsPath = (fs::u8path(path) / "Assets").string();
+    fs::path assetsPath = fs::u8path(path) / "Assets";
     std::error_code ec;
     if (fs::is_directory(assetsPath, ec))
-        m_currentPath = assetsPath;
+        m_currentPath = infernux::FromFsPath(assetsPath);
     else
         m_currentPath = path;
 }
@@ -474,7 +477,7 @@ void ProjectPanel::SetIconsDirectory(const std::string &dir)
 void ProjectPanel::SetCurrentPath(const std::string &path)
 {
     std::error_code ec;
-    if (!path.empty() && fs::is_directory(path, ec))
+    if (!path.empty() && fs::is_directory(fs::u8path(path), ec))
         m_currentPath = path;
 }
 
@@ -499,7 +502,7 @@ void ProjectPanel::SetSelectedFile(const std::string &path)
     fs::path selectedPath = fs::u8path(path);
     fs::path parent = selectedPath.parent_path();
     if (!parent.empty() && fs::is_directory(parent, ec))
-        m_currentPath = parent.string();
+        m_currentPath = infernux::FromFsPath(parent);
 
     m_selectedFile = path;
     m_selectedFiles = {path};
@@ -623,7 +626,7 @@ ProjectPanel::DirSnapshot *ProjectPanel::GetDirSnapshot(const std::string &path)
     for (auto &entry : fs::directory_iterator(fs::u8path(path), ec)) {
         if (ec)
             break;
-        auto name = entry.path().filename().string();
+        auto name = infernux::FromFsPath(entry.path().filename());
         if (!ShouldShow(name))
             continue;
 
@@ -635,14 +638,14 @@ ProjectPanel::DirSnapshot *ProjectPanel::GetDirSnapshot(const std::string &path)
 
         FileItem item;
         item.name = std::move(name);
-        item.path = entry.path().string();
+        item.path = infernux::FromFsPath(entry.path());
 
         if (isDir) {
             item.type = FileItem::Dir;
             snap.dirs.push_back(std::move(item));
         } else {
             item.type = FileItem::File;
-            auto ext = entry.path().extension().string();
+            auto ext = infernux::FromFsPath(entry.path().extension());
             for (auto &c : ext)
                 c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
             item.ext = std::move(ext);
@@ -659,14 +662,17 @@ ProjectPanel::DirSnapshot *ProjectPanel::GetDirSnapshot(const std::string &path)
         }
     }
 
-    // Sort case-insensitive
+    // Sort: ASCII case-insensitive; leave UTF-8 bytes unchanged outside ASCII letters.
     auto cmpName = [](const FileItem &a, const FileItem &b) {
-        auto la = a.name, lb = b.name;
-        for (auto &c : la)
-            c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
-        for (auto &c : lb)
-            c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
-        return la < lb;
+        auto asciiLowerCopy = [](std::string s) {
+            for (auto &c : s) {
+                unsigned char uc = static_cast<unsigned char>(c);
+                if (uc >= 'A' && uc <= 'Z')
+                    c = static_cast<char>(uc + 32);
+            }
+            return s;
+        };
+        return asciiLowerCopy(a.name) < asciiLowerCopy(b.name);
     };
     std::sort(snap.dirs.begin(), snap.dirs.end(), cmpName);
     std::sort(snap.files.begin(), snap.files.end(), cmpName);
@@ -696,7 +702,7 @@ ProjectPanel::DirTreeMeta *ProjectPanel::GetDirTreeMeta(const std::string &path)
     for (auto &entry : fs::directory_iterator(fs::u8path(path), ec)) {
         if (ec)
             break;
-        auto name = entry.path().filename().string();
+        auto name = infernux::FromFsPath(entry.path().filename());
         if (!ShouldShow(name))
             continue;
         if (entry.is_directory(ec) && !ec) {
@@ -1048,10 +1054,11 @@ void ProjectPanel::EnsureTypeIconsLoaded()
             continue;
         }
 
-        auto iconPath = (fs::u8path(m_iconsDir) / (iconKey + ".png")).string();
-        if (!fs::is_regular_file(iconPath, ec))
+        fs::path iconFs = fs::u8path(m_iconsDir) / (iconKey + ".png");
+        if (!fs::is_regular_file(iconFs, ec))
             continue;
 
+        auto iconPath = infernux::FromFsPath(iconFs);
         auto texData = InxTextureLoader::LoadFromFile(iconPath);
         if (!texData.IsValid())
             continue;
@@ -1421,10 +1428,10 @@ void ProjectPanel::BeginRename(const std::string &path)
         return;
 
     m_renamingPath = path;
-    auto name = fs::u8path(path).filename().string();
+    auto name = infernux::FromFsPath(fs::u8path(path).filename());
     std::error_code ec;
-    if (fs::is_regular_file(path, ec)) {
-        auto stem = fs::u8path(path).stem().string();
+    if (fs::is_regular_file(fs::u8path(path), ec)) {
+        auto stem = infernux::FromFsPath(fs::u8path(path).stem());
         if (!stem.empty())
             name = stem;
     }
@@ -1479,7 +1486,7 @@ void ProjectPanel::CreateAndRename(const std::string &baseName, const std::strin
     std::string fileName = name;
     if (!extension.empty() && fileName.find(extension) == std::string::npos)
         fileName += extension;
-    auto newPath = (fs::u8path(m_currentPath) / fileName).string();
+    auto newPath = infernux::FromFsPath(fs::u8path(m_currentPath) / fileName);
 
     m_selectedFile = newPath;
     m_selectedFiles = {newPath};
@@ -1727,7 +1734,7 @@ void ProjectPanel::MoveProjectItemsToFolder(const std::string &targetDir, const 
                                             const std::string &payload)
 {
     std::error_code ec;
-    if (targetDir.empty() || !fs::is_directory(targetDir, ec))
+    if (targetDir.empty() || !fs::is_directory(fs::u8path(targetDir), ec))
         return;
 
     auto draggedPath = ResolveMovePayloadPath(payloadType, payload);
@@ -1745,7 +1752,7 @@ void ProjectPanel::MoveProjectItemsToFolder(const std::string &targetDir, const 
 
     std::vector<std::string> movedPaths;
     for (auto &source : sources) {
-        if (fs::is_directory(source, ec) && IsPathWithin(targetDir, source))
+        if (fs::is_directory(fs::u8path(source), ec) && IsPathWithin(targetDir, source))
             continue; // Can't move folder into itself
 
         if (moveItemToDirectory) {
@@ -1838,9 +1845,9 @@ void ProjectPanel::RenderBreadcrumb(InxGUIContext *ctx)
         m_breadcrumbPath = m_currentPath;
         if (!m_rootPath.empty()) {
             auto rel = fs::relative(fs::u8path(m_currentPath), fs::u8path(m_rootPath));
-            auto relStr = rel.string();
+            auto relStr = infernux::FromFsPath(rel);
             if (relStr == ".")
-                relStr = fs::u8path(m_rootPath).filename().string();
+                relStr = infernux::FromFsPath(fs::u8path(m_rootPath).filename());
             m_breadcrumbText = "Path: " + relStr;
         } else {
             m_breadcrumbText = "Path: " + m_currentPath;
@@ -1857,7 +1864,7 @@ void ProjectPanel::RenderFolderTree(InxGUIContext *ctx)
 {
     auto *rootSnap = m_rootPath.empty() ? nullptr : GetDirSnapshot(m_rootPath);
     if (rootSnap) {
-        auto projectName = fs::u8path(m_rootPath).filename().string();
+        auto projectName = infernux::FromFsPath(fs::u8path(m_rootPath).filename());
         int rootFlags =
             ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_SpanAvailWidth | ImGuiTreeNodeFlags_FramePadding;
         if (m_currentPath == m_rootPath)
@@ -1934,7 +1941,7 @@ void ProjectPanel::RenderFileGrid(InxGUIContext *ctx)
         return;
 
     // Back button
-    auto parent = fs::u8path(m_currentPath).parent_path().string();
+    auto parent = infernux::FromFsPath(fs::u8path(m_currentPath).parent_path());
     if (m_currentPath != m_rootPath && parent != m_rootPath) {
         if (ctx->Selectable("[..]", false))
             m_currentPath = parent;
@@ -2331,7 +2338,7 @@ void ProjectPanel::RenderDragDropSource(InxGUIContext *ctx, const FileItem &item
         }
 
         // Other embedded FBX sub-entries: parent model asset (GUID when possible).
-        std::string ext = fs::u8path(item.parentPath).extension().string();
+        std::string ext = infernux::FromFsPath(fs::u8path(item.parentPath).extension());
         for (auto &c : ext)
             c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
 

--- a/cpp/infernux/function/renderer/shader/ShaderCache.cpp
+++ b/cpp/infernux/function/renderer/shader/ShaderCache.cpp
@@ -167,7 +167,7 @@ void ShaderCache::PrecompileShaders(
             continue;
         }
 
-        std::string ext = entry.path().extension().string();
+        std::string ext = FromFsPath(entry.path().extension());
         bool isShader = false;
         for (const auto &shaderExt : shaderExtensions) {
             if (ext == shaderExt) {

--- a/cpp/infernux/function/resources/AssetDatabase/AssetDatabase.cpp
+++ b/cpp/infernux/function/resources/AssetDatabase/AssetDatabase.cpp
@@ -383,7 +383,7 @@ std::string AssetDatabase::NormalizePath(const std::string &path) const
 
 bool AssetDatabase::IsMetaFile(const std::filesystem::path &path) const
 {
-    return path.extension().string() == ".meta";
+    return FromFsPath(path.extension()) == ".meta";
 }
 
 void AssetDatabase::UpdateMapping(const std::string &guid, const std::string &path)
@@ -419,7 +419,7 @@ void AssetDatabase::RunImporter(const std::string &guid, const std::string &path
     if (guid.empty() || path.empty())
         return;
 
-    std::string ext = ToFsPath(path).extension().string();
+    std::string ext = FromFsPath(ToFsPath(path).extension());
     if (ext.empty())
         return;
 
@@ -516,7 +516,7 @@ bool AssetDatabase::ReadFile(const std::string &filePath, std::vector<char> &con
 bool AssetDatabase::IsBinaryFile(const std::string &filePath) const
 {
     std::filesystem::path path = ToFsPath(filePath);
-    std::string extension = path.extension().string();
+    std::string extension = FromFsPath(path.extension());
 
     std::transform(extension.begin(), extension.end(), extension.begin(), ::tolower);
 
@@ -626,7 +626,7 @@ ResourceType AssetDatabase::GetResourcesType(const std::string &extensionName) c
 ResourceType AssetDatabase::GetResourceTypeForPath(const std::string &filePath) const
 {
     std::filesystem::path path = ToFsPath(filePath);
-    std::string ext = path.extension().string();
+    std::string ext = FromFsPath(path.extension());
     return GetResourcesType(ext);
 }
 
@@ -805,7 +805,7 @@ void AssetDatabase::MoveResource(const std::string &oldPath, const std::string &
 
         INXLOG_INFO("MoveResource: ", oldPath, " -> ", newPath, " (guid preserved: ", existingGuid, ")");
     } else {
-        std::string ext = ToFsPath(newPath).extension().string();
+        std::string ext = FromFsPath(ToFsPath(newPath).extension());
         ResourceType type = GetResourcesType(ext);
 
         if (type != ResourceType::Meta) {

--- a/cpp/infernux/function/resources/AssetImporter/ConcreteImporters.cpp
+++ b/cpp/infernux/function/resources/AssetImporter/ConcreteImporters.cpp
@@ -133,7 +133,7 @@ bool ModelImporter::Import(const ImportContext &ctx)
 
     // Minimal flags: triangulate so we can count real triangle-indices,
     // but skip heavy post-processing (that happens at load time in MeshLoader).
-    std::string ext = sourcePath.extension().string();
+    std::string ext = FromFsPath(sourcePath.extension());
     if (!ext.empty() && ext[0] == '.')
         ext.erase(0, 1);
     const aiScene *scene = importer.ReadFileFromMemory(fileData.data(), static_cast<size_t>(fileData.size()),

--- a/cpp/infernux/function/resources/InxFileLoader/InxDefaultLoader.cpp
+++ b/cpp/infernux/function/resources/InxFileLoader/InxDefaultLoader.cpp
@@ -28,7 +28,7 @@ void InxDefaultTextLoader::CreateMeta(const char *content, size_t contentSize, c
     metaData.Init(content, contentSize, filePath, ResourceType::DefaultText);
 
     std::filesystem::path path = ToFsPath(filePath);
-    std::string extension = path.extension().string();
+    std::string extension = FromFsPath(path.extension());
 
     // For text files, analyze content
     std::string contentStr;
@@ -79,7 +79,7 @@ void InxDefaultBinaryLoader::CreateMeta(const char *content, size_t contentSize,
     metaData.Init(content, contentSize, filePath, ResourceType::DefaultBinary);
 
     std::filesystem::path path = ToFsPath(filePath);
-    std::string extension = path.extension().string();
+    std::string extension = FromFsPath(path.extension());
 
     // Add basic metadata for binary files
     metaData.AddMetadata("file_type", std::string("binary"));

--- a/cpp/infernux/function/resources/InxFileLoader/InxPythonScriptLoader.cpp
+++ b/cpp/infernux/function/resources/InxFileLoader/InxPythonScriptLoader.cpp
@@ -34,7 +34,7 @@ void InxPythonScriptLoader::CreateMeta(const char *content, size_t contentSize, 
     metaData.Init(content, contentSize, filePath, ResourceType::Script);
 
     std::filesystem::path path = ToFsPath(filePath);
-    std::string extension = path.extension().string();
+    std::string extension = FromFsPath(path.extension());
     std::string contentStr;
     if (content && contentSize > 0) {
         contentStr.assign(content, contentSize);

--- a/cpp/infernux/function/resources/InxFileLoader/InxShaderLoader.cpp
+++ b/cpp/infernux/function/resources/InxFileLoader/InxShaderLoader.cpp
@@ -270,7 +270,7 @@ ShaderDescriptor InxShaderLoader::ParseShaderSource(const std::string &source, c
     // Infer stage from file extension
     if (!filePath.empty()) {
         const std::filesystem::path fsPath = ToFsPath(filePath);
-        desc.fileExtension = fsPath.extension().string();
+        desc.fileExtension = FromFsPath(fsPath.extension());
         desc.isVertexShader = (desc.fileExtension == ".vert");
         desc.isFragmentShader = (desc.fileExtension == ".frag");
         desc.isComputeShader = (desc.fileExtension == ".comp");
@@ -1239,7 +1239,7 @@ std::unordered_map<std::string, std::string> InxShaderLoader::BuildShaderIdMap(c
             if (!entry.is_regular_file())
                 continue;
 
-            auto ext = entry.path().extension().string();
+            auto ext = FromFsPath(entry.path().extension());
             if (ext != ".vert" && ext != ".frag" && ext != ".glsl" && ext != ".shadingmodel")
                 continue;
 

--- a/cpp/infernux/function/resources/InxMesh/MeshLoader.cpp
+++ b/cpp/infernux/function/resources/InxMesh/MeshLoader.cpp
@@ -405,7 +405,7 @@ std::shared_ptr<void> MeshLoader::Load(const std::string &filePath, const std::s
     unsigned int flags = BuildAssimpFlags(settings);
 
     // Derive extension hint for Assimp (e.g. "fbx")
-    std::string ext = fsPath.extension().string();
+    std::string ext = FromFsPath(fsPath.extension());
     if (!ext.empty() && ext[0] == '.')
         ext = ext.substr(1);
 
@@ -472,7 +472,7 @@ void MeshLoader::CreateMeta(const char *content, size_t contentSize, const std::
     metaData.Init(content, contentSize, filePath, ResourceType::Mesh);
 
     std::filesystem::path path = ToFsPath(filePath);
-    std::string extension = path.extension().string();
+    std::string extension = FromFsPath(path.extension());
 
     metaData.AddMetadata("file_type", std::string("mesh"));
     metaData.AddMetadata("file_extension", extension);

--- a/cpp/infernux/function/resources/InxSkinnedMesh/SkinnedModelCache.cpp
+++ b/cpp/infernux/function/resources/InxSkinnedMesh/SkinnedModelCache.cpp
@@ -242,7 +242,7 @@ std::shared_ptr<InxSkinnedMesh> SkinnedModelCache::ImportModel(const std::string
     }
 
     auto fsPath = ToFsPath(sourcePath);
-    std::string ext = fsPath.extension().string();
+    std::string ext = FromFsPath(fsPath.extension());
     if (!ext.empty() && ext[0] == '.')
         ext = ext.substr(1);
 

--- a/cpp/infernux/function/resources/InxTexture/TextureLoader.cpp
+++ b/cpp/infernux/function/resources/InxTexture/TextureLoader.cpp
@@ -36,7 +36,7 @@ void TextureLoader::CreateMeta(const char *content, size_t contentSize, const st
     metaData.Init(content, contentSize, filePath, ResourceType::Texture);
 
     std::filesystem::path path = ToFsPath(filePath);
-    std::string extension = path.extension().string();
+    std::string extension = FromFsPath(path.extension());
     std::transform(extension.begin(), extension.end(), extension.begin(), ::tolower);
 
     // Get image dimensions without fully loading the pixel data

--- a/cpp/infernux/function/resources/ShaderAsset/ShaderLoader.cpp
+++ b/cpp/infernux/function/resources/ShaderAsset/ShaderLoader.cpp
@@ -46,7 +46,7 @@ static std::shared_ptr<ShaderAsset> CompileShaderAsset(const std::string &filePa
 
     // Determine shader type from extension
     std::filesystem::path fsPath = ToFsPath(filePath);
-    std::string ext = fsPath.extension().string();
+    std::string ext = FromFsPath(fsPath.extension());
 
     // Read metadata for shader_id
     const InxResourceMeta *meta = adb->GetMetaByGuid(guid);

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -79,7 +79,13 @@ add_subdirectory(assimp)
 add_library(assimp::assimp ALIAS assimp)
 
 # glslang
+# Keep glslang static even though most runtime dependencies are shared.
+# Its C++ API exposes some inline/non-exported helpers that are fragile when
+# consumed through a Windows DLL import library with MSVC.
+set(_saved_shared_for_glslang "${BUILD_SHARED_LIBS}")
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
 add_subdirectory(glslang)
+set(BUILD_SHARED_LIBS "${_saved_shared_for_glslang}" CACHE BOOL "" FORCE)
 add_library(glslang::glslang ALIAS glslang)
 
 # glm (header-only library)

--- a/packaging/embed_runtime_manager.py
+++ b/packaging/embed_runtime_manager.py
@@ -12,7 +12,7 @@ import zipfile
 from pathlib import Path
 from typing import Callable, Optional
 
-from hub_utils import get_bundle_dir, get_hub_data_dir, is_frozen
+from hub_utils import get_bundle_dir, get_hub_data_dir, is_frozen, merge_child_env_utf8
 from runtime_requirements import runtime_modules, runtime_packages
 import logging
 
@@ -92,7 +92,7 @@ def _run_command(args: list[str], *, timeout: int, raise_on_error: bool = False)
         "text": True,
         "encoding": "utf-8",
         "errors": "replace",
-        "env": {**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        "env": merge_child_env_utf8({"PYTHONDONTWRITEBYTECODE": "1"}),
     }
     if sys.platform == "win32":
         kwargs["creationflags"] = _NO_WINDOW
@@ -255,6 +255,7 @@ def _remove_tree(path: str) -> None:
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             creationflags=_NO_WINDOW,
+            env=merge_child_env_utf8(),
         )
         if completed.returncode == 0 and not os.path.exists(path):
             return
@@ -294,6 +295,7 @@ def _copy_tree_fast(src: str, dest: str, *, exclude_runtime_artifacts: bool = Fa
         encoding="utf-8",
         errors="replace",
         creationflags=_NO_WINDOW,
+        env=merge_child_env_utf8(),
     )
     if completed.returncode < 8:
         return True

--- a/packaging/hub_utils.py
+++ b/packaging/hub_utils.py
@@ -131,6 +131,15 @@ def write_project_lock(project_path: str, pid: int, token: str, mode: str, state
     return lock_path
 
 
+def merge_child_env_utf8(extra: dict[str, str] | None = None) -> dict[str, str]:
+    """Environment for subprocesses: inherit current env and prefer UTF-8 on Windows."""
+    merged = {**os.environ, **(extra or {})}
+    if sys.platform == "win32":
+        merged.setdefault("PYTHONUTF8", "1")
+        merged.setdefault("PYTHONIOENCODING", "utf-8")
+    return merged
+
+
 def remove_project_lock(project_path: str, token: str | None = None) -> None:
     """Remove the project lock if it exists and the token matches when provided."""
     lock_path = get_project_lock_path(project_path)

--- a/packaging/infernux_hub.spec
+++ b/packaging/infernux_hub.spec
@@ -56,6 +56,7 @@ a = Analysis(
         "_hashlib",
         "database",
         "splash_screen",
+        "Infernux.runtime_utf8",
         "style",
         "ui_project_list",
         "model",
@@ -72,7 +73,7 @@ a = Analysis(
     ],
     hookspath=[],
     hooksconfig={},
-    runtime_hooks=[],
+    runtime_hooks=[os.path.join(_PACKAGING_DIR, "pyi_rth_infernux_utf8.py")],
     excludes=[
         # Don't bundle the engine itself — it's installed per-project
         "Infernux",

--- a/packaging/infernux_hub_installer.spec
+++ b/packaging/infernux_hub_installer.spec
@@ -48,7 +48,7 @@ a = Analysis(
     ],
     hookspath=[],
     hooksconfig={},
-    runtime_hooks=[],
+    runtime_hooks=[os.path.join(_PACKAGING_DIR, "pyi_rth_infernux_utf8.py")],
     excludes=[],
     noarchive=False,
     optimize=0,

--- a/packaging/installer_gui.py
+++ b/packaging/installer_gui.py
@@ -118,6 +118,9 @@ def _create_start_menu_shortcut(install_dir: str) -> None:
             f'$s.Save()'
         )
         import subprocess
+
+        from hub_utils import merge_child_env_utf8
+
         subprocess.run(
             ["powershell", "-NoProfile", "-Command", ps_script],
             stdin=subprocess.DEVNULL,
@@ -125,6 +128,7 @@ def _create_start_menu_shortcut(install_dir: str) -> None:
             stderr=subprocess.DEVNULL,
             timeout=15,
             creationflags=0x08000000,
+            env=merge_child_env_utf8(),
         )
     except Exception as _exc:
         logging.getLogger(__name__).debug("[Suppressed] %s: %s", type(_exc).__name__, _exc)

--- a/packaging/launcher.py
+++ b/packaging/launcher.py
@@ -1,5 +1,21 @@
 import os
 import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_PYTHON_DIR = _REPO_ROOT / "python"
+if str(_PYTHON_DIR) not in sys.path:
+    sys.path.insert(0, str(_PYTHON_DIR))
+
+try:
+    from Infernux.runtime_utf8 import configure_process_utf8
+
+    configure_process_utf8()
+except Exception:
+    if sys.platform == "win32":
+        os.environ.setdefault("PYTHONUTF8", "1")
+        os.environ.setdefault("PYTHONIOENCODING", "utf-8")
+
 sys.dont_write_bytecode = True
 
 from PySide6.QtWidgets import (

--- a/packaging/model/project_model.py
+++ b/packaging/model/project_model.py
@@ -6,6 +6,7 @@ import subprocess
 import shutil
 import glob
 import zipfile
+import sysconfig
 
 from hub_utils import is_frozen, is_project_open, merge_child_env_utf8
 from python_runtime import PythonRuntimeError, PythonRuntimeManager
@@ -72,17 +73,137 @@ _NATIVE_IMPORT_SMOKE_TEST = (
 )
 
 
-def _find_dev_wheel() -> str:
+def _python_cp_tag(python_exe: str = "") -> str:
+    if python_exe:
+        try:
+            completed = subprocess.run(
+                [python_exe, "-c", "import sys; print(f'cp{sys.version_info.major}{sys.version_info.minor}')"],
+                timeout=30,
+                **_popen_kwargs(capture_output=True),
+            )
+            if completed.returncode == 0:
+                tag = (completed.stdout or "").strip()
+                if tag.startswith("cp"):
+                    return tag
+        except (OSError, subprocess.SubprocessError) as _exc:
+            logging.getLogger(__name__).debug("[Suppressed] %s: %s", type(_exc).__name__, _exc)
+    return f"cp{sys.version_info.major}{sys.version_info.minor}"
+
+
+def _engine_root() -> str:
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+def _iter_cmake_python_cache_entries() -> list[str]:
+    cache_path = os.path.join(_engine_root(), "out", "build", "CMakeCache.txt")
+    if not os.path.isfile(cache_path):
+        return []
+
+    keys = (
+        "Python3_EXECUTABLE",
+        "_Python3_EXECUTABLE",
+        "PYBIND11_PYTHON_EXECUTABLE_LAST",
+    )
+    out: list[str] = []
+    try:
+        with open(cache_path, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                if "=" not in line:
+                    continue
+                key_part, value = line.rstrip("\n").split("=", 1)
+                key = key_part.split(":", 1)[0]
+                if key in keys and value:
+                    out.append(os.path.normpath(value.strip()))
+    except OSError as _exc:
+        logging.getLogger(__name__).debug("[Suppressed] %s: %s", type(_exc).__name__, _exc)
+    return out
+
+
+def _iter_dev_project_python_candidates() -> list[str]:
+    candidates: list[str] = []
+
+    override = os.environ.get("INFERNUX_PROJECT_PYTHON", "").strip()
+    if override:
+        candidates.append(os.path.normpath(override))
+
+    candidates.extend(_iter_cmake_python_cache_entries())
+    candidates.append(sys.executable)
+
+    seen: set[str] = set()
+    unique: list[str] = []
+    for candidate in candidates:
+        if not candidate:
+            continue
+        norm = os.path.normcase(os.path.abspath(candidate))
+        if norm in seen:
+            continue
+        seen.add(norm)
+        unique.append(candidate)
+    return unique
+
+
+def _select_dev_project_python() -> str:
+    """Choose the interpreter used to create project .venv in dev mode.
+
+    Prefer the Python that CMake used to build the native wheel.  Launching the
+    Hub from a different Python should not silently create an incompatible
+    project virtual environment.
+    """
+    fallback = sys.executable
+    for candidate in _iter_dev_project_python_candidates():
+        if not os.path.isfile(candidate):
+            continue
+        if _find_dev_wheel(candidate):
+            return candidate
+        if os.path.normcase(os.path.abspath(candidate)) == os.path.normcase(os.path.abspath(sys.executable)):
+            fallback = candidate
+    return fallback
+
+
+def _wheel_tag_parts(wheel_path: str) -> tuple[set[str], set[str], set[str]]:
+    name = os.path.basename(wheel_path or "")
+    if not name.lower().endswith(".whl"):
+        return set(), set(), set()
+    parts = name[:-4].split("-")
+    if len(parts) < 5:
+        return set(), set(), set()
+    return set(parts[-3].split(".")), set(parts[-2].split(".")), set(parts[-1].split("."))
+
+
+def _wheel_matches_python(wheel_path: str, python_tag: str) -> bool:
+    python_tags, abi_tags, platform_tags = _wheel_tag_parts(wheel_path)
+    if not python_tags or not abi_tags or not platform_tags:
+        return False
+
+    major_tag = f"py{python_tag[2]}" if python_tag.startswith("cp") and len(python_tag) >= 3 else "py3"
+    platform_tag = sysconfig.get_platform().replace("-", "_").replace(".", "_")
+    return (
+        (python_tag in python_tags or major_tag in python_tags or "py3" in python_tags)
+        and (python_tag in abi_tags or "abi3" in abi_tags or "none" in abi_tags)
+        and (platform_tag in platform_tags or "any" in platform_tags)
+    )
+
+
+def _find_dev_wheel(python_exe: str = "", *, strict: bool = False) -> str:
     """Find the Infernux wheel in the dist/ directory next to the engine source.
 
     Only used in dev mode (non-frozen).
     """
-    engine_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    engine_root = _engine_root()
     dist_dir = os.path.join(engine_root, "dist")
     wheels = glob.glob(os.path.join(dist_dir, "infernux-*.whl"))
     if wheels:
-        wheels.sort(key=os.path.getmtime, reverse=True)
-        return wheels[0]
+        python_tag = _python_cp_tag(python_exe)
+        compatible = [wheel for wheel in wheels if _wheel_matches_python(wheel, python_tag)]
+        if compatible:
+            compatible.sort(key=os.path.getmtime, reverse=True)
+            return compatible[0]
+        if strict:
+            available = ", ".join(os.path.basename(wheel) for wheel in sorted(wheels))
+            raise RuntimeError(
+                f"No prebuilt Infernux wheel compatible with Python {python_tag} was found in dist/.\n"
+                f"Available wheels: {available}"
+            )
     return ""
 
 
@@ -296,6 +417,7 @@ class ProjectModel:
             self._install_infernux_in_runtime(project_dir, engine_version, on_status=on_status)
         except Exception:
             shutil.rmtree(os.path.join(project_dir, ".runtime"), ignore_errors=True)
+            shutil.rmtree(os.path.join(project_dir, ".venv"), ignore_errors=True)
             raise
 
         # ── Create VS Code workspace configuration ─────────────────────
@@ -372,9 +494,12 @@ class ProjectModel:
 
         # Dev mode: create a classic .venv
         venv_path = os.path.join(project_dir, ".venv")
+        if os.path.exists(venv_path):
+            _remove_tree(venv_path)
+        source_python = _select_dev_project_python()
         if on_status:
-            on_status("Creating project virtual environment...")
-        _run_hidden([sys.executable, "-m", "venv", "--copies", venv_path], timeout=600)
+            on_status(f"Creating project virtual environment with {os.path.basename(source_python)}...")
+        _run_hidden([source_python, "-m", "venv", "--copies", "--system-site-packages", venv_path], timeout=600)
 
     def _install_infernux_in_runtime(self, project_dir: str, engine_version: str = "", *, on_status=None):
         """Install the Infernux wheel into the project's Python environment.
@@ -399,7 +524,7 @@ class ProjectModel:
             wheel = self.version_manager.get_wheel_path(engine_version) or ""
 
         if not wheel and not is_frozen():
-            wheel = _find_dev_wheel()
+            wheel = _find_dev_wheel(project_python, strict=True)
 
         if not wheel:
             if is_frozen():
@@ -441,6 +566,7 @@ class ProjectModel:
             "--prefer-binary",
             "--only-binary=:all:",
             "--no-cache-dir",
+            "--no-deps",
         ]
 
         pip_args = [project_python, "-m", "pip", "install", *_PIP_FLAGS]

--- a/packaging/model/project_model.py
+++ b/packaging/model/project_model.py
@@ -7,7 +7,7 @@ import shutil
 import glob
 import zipfile
 
-from hub_utils import is_frozen, is_project_open
+from hub_utils import is_frozen, is_project_open, merge_child_env_utf8
 from python_runtime import PythonRuntimeError, PythonRuntimeManager
 import logging
 
@@ -23,7 +23,7 @@ def _popen_kwargs(*, capture_output: bool = False) -> dict:
     """
     kw: dict = {
         "stdin": subprocess.DEVNULL,
-        "env": {**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        "env": merge_child_env_utf8({"PYTHONDONTWRITEBYTECODE": "1"}),
     }
     if capture_output:
         kw["stdout"] = subprocess.PIPE
@@ -150,6 +150,7 @@ def _remove_tree(path: str) -> None:
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             creationflags=_NO_WINDOW,
+            env=merge_child_env_utf8(),
         )
         if completed.returncode == 0 and not os.path.exists(path):
             return
@@ -265,7 +266,7 @@ class ProjectModel:
 
         # Create a README file in assets
         readme_path = os.path.join(project_dir, "Assets", "README.md")
-        with open(readme_path, "w") as f:
+        with open(readme_path, "w", encoding="utf-8", newline="\n") as f:
             f.write("# Project Assets\n\nThis folder contains all the assets for the project.\n")
 
         # Create default project requirements

--- a/packaging/pyi_rth_infernux_utf8.py
+++ b/packaging/pyi_rth_infernux_utf8.py
@@ -1,0 +1,8 @@
+# PyInstaller runtime hook — set UTF-8 before importing the Hub (Windows).
+# -*- coding: utf-8 -*-
+import os
+import sys
+
+if sys.platform == "win32":
+    os.environ.setdefault("PYTHONUTF8", "1")
+    os.environ.setdefault("PYTHONIOENCODING", "utf-8")

--- a/packaging/splash_screen.py
+++ b/packaging/splash_screen.py
@@ -13,7 +13,7 @@ from PySide6.QtWidgets import QWidget, QApplication, QLabel, QVBoxLayout, QGraph
 from PySide6.QtCore import Qt, QTimer, QSize, QPropertyAnimation, QEasingCurve
 from PySide6.QtGui import QPixmap, QFont, QPainter, QColor, QPen, QBrush
 
-from hub_utils import get_project_lock_path, remove_project_lock, write_project_lock
+from hub_utils import get_project_lock_path, merge_child_env_utf8, remove_project_lock, write_project_lock
 
 
 _WIN_CRASH_CODES = {
@@ -251,6 +251,7 @@ class EngineSplashScreen(QWidget):
         env["_INFERNUX_PROJECT_LOCK_TOKEN"] = self._lock_token
         if extra_env:
             env.update(extra_env)
+        env = merge_child_env_utf8(env)
         write_project_lock(project_path, os.getpid(), self._lock_token, "editor", "launching")
 
         popen_kwargs: dict = {"cwd": project_path, "env": env}

--- a/packaging/stage_bundled_python_runtime.py
+++ b/packaging/stage_bundled_python_runtime.py
@@ -22,6 +22,14 @@ import logging
 _RUNTIME_PACKAGES = runtime_packages()
 _RUNTIME_MODULES = runtime_modules()
 _RUNTIME_PROFILE_FILENAME = ".infernux-runtime-profile.json"
+
+
+def _child_env(extra: dict[str, str] | None = None) -> dict[str, str]:
+    env = {**os.environ, **(extra or {})}
+    if sys.platform == "win32":
+        env.setdefault("PYTHONUTF8", "1")
+        env.setdefault("PYTHONIOENCODING", "utf-8")
+    return env
 _RUNTIME_PRUNE_DIR_NAMES = {"__pycache__", ".pytest_cache", "test", "tests"}
 _RUNTIME_PRUNE_FILE_SUFFIXES = (".pyc", ".pyo")
 if sys.platform == "win32":
@@ -46,7 +54,7 @@ def _run(args: list[str], *, timeout: int = 20) -> subprocess.CompletedProcess:
         "encoding": "utf-8",
         "errors": "replace",
         "timeout": timeout,
-        "env": {**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        "env": _child_env({"PYTHONDONTWRITEBYTECODE": "1"}),
     }
     if sys.platform == "win32":
         kwargs["creationflags"] = 0x08000000
@@ -579,7 +587,10 @@ def main() -> int:
                 continue
             if os.path.normcase(os.path.abspath(candidate)) == current:
                 continue
-            completed = subprocess.run([candidate, __file__, *sys.argv[1:]])
+            completed = subprocess.run(
+                [candidate, __file__, *sys.argv[1:]],
+                env=_child_env(),
+            )
             return completed.returncode
         raise SystemExit(
             f"This staging script must run under Python 3.12, but got {sys.version.split()[0]} from {sys.executable}."

--- a/python/Infernux/engine/__init__.py
+++ b/python/Infernux/engine/__init__.py
@@ -1,3 +1,7 @@
+from Infernux.runtime_utf8 import configure_process_utf8
+
+configure_process_utf8()
+
 import atexit
 import json
 import os

--- a/python/Infernux/engine/_bootstrap_panels.py
+++ b/python/Infernux/engine/_bootstrap_panels.py
@@ -37,6 +37,7 @@ from Infernux.engine.ui import (
     editor_panel,
 )
 from Infernux.engine.ui import panel_state as _panel_state
+from Infernux.engine._bootstrap_trace import bootstrap_checkpoint
 
 
 class BootstrapPanelsMixin:

--- a/python/Infernux/engine/_bootstrap_trace.py
+++ b/python/Infernux/engine/_bootstrap_trace.py
@@ -1,0 +1,36 @@
+"""Minimal bootstrap breadcrumbs for diagnosing editor startup hangs (no heavy imports)."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+
+def bootstrap_checkpoint(message: str) -> None:
+    """Write the last completed bootstrap sub-step to the temp directory.
+
+    On Windows this is typically ``%TEMP%\\Infernux_bootstrap_checkpoint.txt``.
+    If the editor freezes during splash loading, support can ask the user to
+    open that file — the final line is the last checkpoint reached.
+
+    Set ``INFERNUX_BOOTSTRAP_TRACE=1`` to also mirror each line to the engine
+    internal log via :mod:`Infernux.debug`.
+    """
+    try:
+        path = os.path.join(tempfile.gettempdir(), "Infernux_bootstrap_checkpoint.txt")
+        with open(path, "w", encoding="utf-8", newline="\n") as f:
+            f.write(message + "\n")
+            f.flush()
+            os.fsync(f.fileno())
+    except OSError:
+        pass
+
+    flag = os.environ.get("INFERNUX_BOOTSTRAP_TRACE", "").strip().lower()
+    if flag not in {"1", "true", "yes", "on"}:
+        return
+    try:
+        from Infernux.debug import Debug
+
+        Debug.log_internal(f"[bootstrap] {message}")
+    except Exception:
+        pass

--- a/python/Infernux/engine/bootstrap.py
+++ b/python/Infernux/engine/bootstrap.py
@@ -472,7 +472,7 @@ class EditorBootstrap(BootstrapPanelsMixin, BootstrapSelectionMixin, BootstrapWi
         need_reset = True
         if os.path.isfile(layout_ver_path):
             try:
-                with open(layout_ver_path, "r") as f:
+                with open(layout_ver_path, "r", encoding="utf-8") as f:
                     if f.read().strip() == str(_LAYOUT_VERSION):
                         need_reset = False
             except OSError as _exc:
@@ -481,7 +481,7 @@ class EditorBootstrap(BootstrapPanelsMixin, BootstrapSelectionMixin, BootstrapWi
             if os.path.isfile(imgui_ini_path):
                 os.remove(imgui_ini_path)
             os.makedirs(os.path.dirname(layout_ver_path), exist_ok=True)
-            with open(layout_ver_path, "w") as f:
+            with open(layout_ver_path, "w", encoding="utf-8", newline="\n") as f:
                 f.write(str(_LAYOUT_VERSION))
 
     def _persist_editor_state(self):

--- a/python/Infernux/engine/nuitka_builder.py
+++ b/python/Infernux/engine/nuitka_builder.py
@@ -632,6 +632,8 @@ def _ensure_windows_msvc_environment(env: dict[str, str]) -> dict[str, str]:
 
 
 def _run_python(python_exe: str, args: List[str], *, timeout: int = 60) -> subprocess.CompletedProcess:
+    from Infernux.runtime_utf8 import merge_child_env
+
     kwargs = {
         "stdin": subprocess.DEVNULL,
         "stdout": subprocess.PIPE,
@@ -640,6 +642,7 @@ def _run_python(python_exe: str, args: List[str], *, timeout: int = 60) -> subpr
         "encoding": "utf-8",
         "errors": "replace",
         "timeout": timeout,
+        "env": merge_child_env({"PYTHONDONTWRITEBYTECODE": "1"}),
     }
     if sys.platform == "win32":
         kwargs["creationflags"] = 0x08000000
@@ -1231,6 +1234,10 @@ class NuitkaBuilder:
 
         if sys.platform == "win32":
             env = _ensure_windows_msvc_environment(env)
+
+        from Infernux.runtime_utf8 import apply_utf8_defaults
+
+        env = apply_utf8_defaults(env)
 
         import time as _time
         _nuitka_proc_t0 = _time.perf_counter()

--- a/python/Infernux/lib/__init__.py
+++ b/python/Infernux/lib/__init__.py
@@ -75,8 +75,6 @@ _SYSTEM_DLL_CHECKS = (
 _ENGINE_DLLS = (
     "SDL3.dll",
     "assimp-vc143-mt.dll",
-    "glslang.dll",
-    "SPIRV.dll",
     "Jolt.dll",
 )
 

--- a/python/Infernux/runtime_utf8.py
+++ b/python/Infernux/runtime_utf8.py
@@ -1,0 +1,42 @@
+"""UTF-8 defaults for Infernux Python processes (especially Windows).
+
+Sets PEP 540-style UTF-8 mode for child processes and best-effort UTF-8
+stdio so Unicode paths and logs behave consistently with the C++ engine
+(ToFsPath / UTF-8 strings).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def configure_process_utf8() -> None:
+    """Apply UTF-8 environment defaults and reconfigure stdio when possible."""
+    if sys.platform == "win32":
+        os.environ.setdefault("PYTHONUTF8", "1")
+        os.environ.setdefault("PYTHONIOENCODING", "utf-8")
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            try:
+                stream.reconfigure(encoding="utf-8", errors="replace")
+            except Exception:
+                pass
+
+
+def merge_child_env(extra: dict[str, str] | None = None) -> dict[str, str]:
+    """Build an environment dict for subprocesses (inherits UTF-8 mode on Windows)."""
+    merged = {**os.environ, **(extra or {})}
+    if sys.platform == "win32":
+        merged.setdefault("PYTHONUTF8", "1")
+        merged.setdefault("PYTHONIOENCODING", "utf-8")
+    return merged
+
+
+def apply_utf8_defaults(env: dict[str, str]) -> dict[str, str]:
+    """Apply UTF-8 defaults to an existing environment mapping (mutates a copy)."""
+    out = dict(env)
+    if sys.platform == "win32":
+        out.setdefault("PYTHONUTF8", "1")
+        out.setdefault("PYTHONIOENCODING", "utf-8")
+    return out

--- a/python/test/test_hub_project_model.py
+++ b/python/test/test_hub_project_model.py
@@ -129,6 +129,72 @@ def test_frozen_project_runtime_direct_install_replaces_old_infernux_only(tmp_pa
     assert dependency_dir.is_dir()
 
 
+def test_dev_wheel_selection_matches_current_python_tag(tmp_path, monkeypatch):
+    project_model = _load_project_model(monkeypatch)
+    monkeypatch.setattr(project_model, "_engine_root", lambda: str(tmp_path))
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir(exist_ok=True)
+    old_wheel = dist_dir / "infernux-0.1.6-cp312-cp312-win_amd64.whl"
+    new_wheel = dist_dir / "infernux-0.1.6-cp313-cp313-win_amd64.whl"
+    old_wheel.write_bytes(b"old")
+    new_wheel.write_bytes(b"new")
+    monkeypatch.setattr(project_model, "_python_cp_tag", lambda _python="": "cp313")
+    monkeypatch.setattr(project_model.sysconfig, "get_platform", lambda: "win-amd64")
+    assert Path(project_model._find_dev_wheel()).name == new_wheel.name
+
+
+def test_dev_project_runtime_uses_selected_python_and_system_site_packages(tmp_path, monkeypatch):
+    project_model = _load_project_model(monkeypatch)
+    monkeypatch.setattr(project_model, "is_frozen", lambda: False)
+    source_python = tmp_path / "python.exe"
+    source_python.write_text("", encoding="utf-8")
+    monkeypatch.setattr(project_model, "_select_dev_project_python", lambda: str(source_python))
+
+    captured_args: list[list[str]] = []
+
+    def fake_run_hidden(args: list[str], *, timeout: int):
+        captured_args.append(args)
+
+    monkeypatch.setattr(project_model, "_run_hidden", fake_run_hidden)
+
+    model = project_model.ProjectModel(None)
+    model._create_project_runtime(str(tmp_path / "project"))
+
+    assert captured_args == [
+        [str(source_python), "-m", "venv", "--copies", "--system-site-packages", str(tmp_path / "project" / ".venv")]
+    ]
+
+
+def test_dev_project_install_uses_local_wheel_without_dependency_resolution(tmp_path, monkeypatch):
+    project_model = _load_project_model(monkeypatch)
+    monkeypatch.setattr(project_model, "is_frozen", lambda: False)
+    monkeypatch.setattr(project_model, "_distribution_files_present", lambda _site_packages, _name: False)
+    monkeypatch.setattr(project_model.ProjectModel, "validate_python_runtime", staticmethod(lambda _python: None))
+    wheel_path = tmp_path / "infernux-0.1.6-cp312-cp312-win_amd64.whl"
+    wheel_path.write_bytes(b"wheel")
+    monkeypatch.setattr(project_model, "_find_dev_wheel", lambda _python, strict=False: str(wheel_path))
+
+    project_dir = tmp_path / "project"
+    python_exe = project_dir / ".venv" / "Scripts" / "python.exe"
+    python_exe.parent.mkdir(parents=True)
+    python_exe.write_text("", encoding="utf-8")
+
+    captured_args: list[list[str]] = []
+
+    def fake_run_hidden(args: list[str], *, timeout: int):
+        captured_args.append(args)
+
+    monkeypatch.setattr(project_model, "_run_hidden", fake_run_hidden)
+
+    model = project_model.ProjectModel(None)
+    model._install_infernux_in_runtime(str(project_dir))
+
+    assert len(captured_args) == 1
+    assert captured_args[0][:4] == [str(python_exe), "-m", "pip", "install"]
+    assert "--no-deps" in captured_args[0]
+    assert captured_args[0][-1] == str(wheel_path)
+
+
 def test_project_runtime_copy_skips_cache_and_test_artifacts(tmp_path, monkeypatch):
     runtime_manager = _load_embed_runtime_manager(monkeypatch)
     source = tmp_path / "source"


### PR DESCRIPTION
# Merge Summary: 017/fix_chinese_path

## Summary

This branch improves Windows UTF-8 handling across the Hub, packaged runtime, editor launch paths, and engine child processes so projects and assets with Chinese or other non-ASCII paths behave consistently. It introduces shared UTF-8 environment helpers, applies them to subprocess creation, PyInstaller hooks, Nuitka/game build flows, and related runtime bootstrap paths.

It also fixes native build and project-creation reliability issues found while validating the branch: glslang is now consumed through a static build path to avoid fragile MSVC DLL import behavior, obsolete glslang/SPIR-V DLL checks were removed, and dev-mode project creation now selects a wheel-compatible Python, installs the local Infernux wheel without dependency resolution, and avoids hanging on PyPI downloads during `Installing Infernux into the project runtime...`.

## What changed

- Added UTF-8 process defaults for Python runtime/bootstrap code, Hub subprocesses, PyInstaller runtime hooks, staged runtime tooling, and game build/Nuitka subprocess environments.
- Updated C++ resource, shader, audio, editor project panel, and asset-loading paths to better preserve UTF-8 path behavior across Windows file-system boundaries.
- Changed glslang integration to keep glslang static while other runtime dependencies remain shared, avoiding `glslang::TProgram::getIntermediate` unresolved externals on MSVC shared-DLL builds.
- Removed stale `glslang.dll` and `SPIRV.dll` native dependency checks from `Infernux.lib` because glslang is no longer expected as a runtime DLL.
- Hardened Hub dev-mode project creation by selecting the Python interpreter that matches the available wheel, creating `.venv` with `--system-site-packages`, installing the local Infernux wheel with `--no-deps`, and cleaning stale `.venv` state on retry/failure.
- Added focused Hub project-model regression tests for frozen direct wheel extraction, compatible wheel selection, dev runtime interpreter selection, and no-dependency local wheel installation.

## Verification

- [x] Built the affected targets
  - `cmake --build --preset release --target _Infernux`
- [x] Ran the relevant tests or static validation
  - `C:\ProgramData\anaconda3\envs\infernux\python.exe -m pytest --noconftest python/test/test_hub_project_model.py -q`
  - Direct `ProjectModel.init_project_folder(...)` smoke test created a temporary project, installed the local wheel, and validated `import Infernux.lib` under Python 3.12.13.
  - VS Code diagnostics reported no errors for `packaging/model/project_model.py` or `python/test/test_hub_project_model.py`.
- [x] Updated docs if behavior or public APIs changed
  - This merge note documents the behavior changes for review; no public API documentation changes were required.

## Notes for reviewers

- The UTF-8 behavior depends on environment propagation (`PYTHONUTF8=1`, `PYTHONIOENCODING=utf-8`) as well as code-path cleanup, so packaged Hub and source-mode Hub launch paths should both be checked when reviewing regressions.
- Dev-mode project creation intentionally uses `--no-deps` for the local Infernux wheel and relies on the selected development Python environment for engine dependencies; project-specific packages remain governed by `ProjectSettings/requirements.txt` at engine startup/build time.
- The focused Hub tests should be run with `--noconftest`; otherwise `python/test/conftest.py` initializes the native engine and can trigger unrelated native shutdown crashes after otherwise passing pure Python tests.
- The glslang static-link choice reduces Windows/MSVC import-library fragility, but reviewers should watch packaging outputs to ensure no workflow still expects `glslang.dll` or `SPIRV.dll` beside `_Infernux`.
