### PR TITLE
add /log to python installation, and related message on installation failure.

### DIFF
--- a/packaging/embed_runtime_manager.py
+++ b/packaging/embed_runtime_manager.py
@@ -630,12 +630,14 @@ class PythonRuntimeManager:
             raise PythonRuntimeError("Infernux Hub currently supports managed Python installation on Windows and macOS only.")
 
         installer_path = self._ensure_runtime_installer(on_status=on_status)
+        install_log_path = os.path.join(os.path.dirname(installer_path), "python-install.log")
         os.makedirs(os.path.dirname(runtime_root), exist_ok=True)
         _emit_status(on_status, "Installing managed Python 3.12 runtime...")
         completed = _run_command(
             [
                 installer_path,
                 "/quiet",
+                "/log", install_log_path,
                 "InstallAllUsers=0",
                 f"TargetDir={runtime_root}",
                 "AssociateFiles=0",
@@ -654,6 +656,7 @@ class PythonRuntimeManager:
         if completed.returncode != 0:
             raise PythonRuntimeError(
                 "Failed to install the managed Python 3.12 runtime.\n"
+                f"Check {install_log_path}.\n"
                 f"{(completed.stderr or completed.stdout or '').strip()}"
             )
 

--- a/packaging/stage_bundled_python_runtime.py
+++ b/packaging/stage_bundled_python_runtime.py
@@ -458,9 +458,11 @@ def _install_full_runtime(dest_root: str, *, installer_cache_root: str | None = 
     if sys.platform != "win32":
         raise SystemExit("Bundled full Python staging is only supported on Windows, macOS, and Linux.")
 
+    install_log_path = os.path.join(os.path.dirname(installer_path), "python-install.log")
     completed = _run([
         installer_path,
         "/quiet",
+        "/log", install_log_path,
         "InstallAllUsers=0",
         f"TargetDir={dest_root}",
         "AssociateFiles=0",
@@ -476,6 +478,7 @@ def _install_full_runtime(dest_root: str, *, installer_cache_root: str | None = 
     if completed.returncode != 0:
         raise SystemExit(
             "Failed to install official Python 3.12 into the bundled runtime directory.\n"
+            f"Check {install_log_path}.\n"
             f"{(completed.stderr or completed.stdout or '').strip()}"
         )
 


### PR DESCRIPTION
## Summary

add /log to python installation, and related message on installation failure.

## What changed

- add /log to python installation, and related message on installation failure.

## Verification

- [x] Built the affected targets
- [x] Ran the relevant tests or static validation
- [x] Updated docs if behavior or public APIs changed

## Notes for reviewers

List any risky areas, migration notes, or tradeoffs that need reviewer attention.

N/A