### PR TITLE
Add `find_package(ZLIB QUIET)` to CMakeLists.txt if assimp don't build zlib.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -383,7 +383,11 @@ if(TARGET zlibstatic)
         ${CMAKE_SOURCE_DIR}/external/assimp/contrib/zlib
         ${CMAKE_BINARY_DIR}/external/assimp/contrib/zlib
     )
-elseif(TARGET ZLIB::zlib)
+else()
+    find_package(ZLIB QUIET)
+endif()
+
+if(TARGET ZLIB::zlib)
     set(INFERNUX_ZLIB_TARGET ZLIB::zlib)
 elseif(TARGET ZLIB::ZLIB)
     set(INFERNUX_ZLIB_TARGET ZLIB::ZLIB)


### PR DESCRIPTION
…find zlib

## Summary

Describe the change in one or two paragraphs.

## What changed

Add `find_package(ZLIB QUIET)` to CMakeLists.txt if assimp don't build zlib.
 
[cmake] --  Build Shared Library: ON
[cmake] --  Build Static Library: OFF
[cmake] -- 
[cmake] -- If something was not detected, although the libraries
[cmake] -- were installed, then make sure you have set the
[cmake] -- CMAKE_C_FLAGS and CMAKE_PREFIX_PATH CMake variables correctly.
[cmake] -- 
[cmake] CMake Error at CMakeLists.txt:391 (message):
[cmake]   Infernux requires a zlib target for document transaction journals
[cmake] 
[cmake] 
[cmake] -- Configuring incomplete, errors occurred!
[proc] The command: /usr/local/bin/cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE -S /home/wokrlie/Projects/Infernux -B /home/wokrlie/Projects/Infernux/out/build-linux -G Ninja exited with code: 1

## Verification

- [x] Built the affected targets
- [x] Ran the relevant tests or static validation
- [ ] Updated docs if behavior or public APIs changed

## Notes for reviewers

List any risky areas, migration notes, or tradeoffs that need reviewer attention.
