### PR TITLE
fix: preserve deferred engine launch errors

### DIFF
--- a/packaging/splash_screen.py
+++ b/packaging/splash_screen.py
@@ -315,11 +315,12 @@ class EngineSplashScreen(QWidget):
         except OSError as exc:
             remove_project_lock(project_path, self._lock_token)
             self._status.setText(tr("Launch failed"))
+            detail = f"The engine process could not be started.\n\n{exc}"
             QTimer.singleShot(
                 0,
                 lambda: self._show_failure(
                     tr("Engine Launch Failed"),
-                    f"The engine process could not be started.\n\n{exc}",
+                    detail,
                 ),
             )
             return


### PR DESCRIPTION
## Summary

When `subprocess.Popen` raises `OSError`, the Hub schedules its failure dialog with `QTimer.singleShot`. Python clears the exception variable after leaving the `except` block, so the deferred callback raises `NameError` and the original launch error is never shown.

## What changed

- Format the launch failure detail while the `OSError` is still available.
- Reuse the captured detail in the existing deferred failure dialog callback.

## Verification

- [ ] Built the affected targets
- [x] Ran the relevant tests or static validation
- [ ] Updated docs if behavior or public APIs changed

Validation performed:

- `QT_QPA_PLATFORM=offscreen pytest -q packaging/tests/test_hub_launch_state.py` (`4 passed`)
- `ruff check packaging/splash_screen.py --select F821`
- `python3 -m py_compile packaging/splash_screen.py`
- `git diff --check`

## Notes for reviewers

- No test files are included in this PR.
- No public API or documentation changes are required.
