### PR TITLE
fix: link dynamic particle shader properties

### DIFF
--- a/python/Infernux/particle/script.py
+++ b/python/Infernux/particle/script.py
@@ -1148,7 +1148,7 @@ class ParticleScriptCompiler:
                             )
                             output_value_links.append(
                                 GraphLinkRecord(
-                                    f"{stage}.shader_property.{index}.{len(shader_property_links)}",
+                                    f"{stage}.shader_property.{index}.{len(output_value_links)}",
                                     source[0],
                                     source[1],
                                     uid,


### PR DESCRIPTION
## Summary

Expression-backed particle output shader properties currently fail during `ParticleScript` parsing because the link identifier references an undefined `shader_property_links` variable. Any dynamic property such as `properties={"tint": ctx.parameter("Tint")}` raises `NameError` instead of producing a value link.

## What changed

- Build the shader-property link identifier from the existing `output_value_links` collection used by the output parser.

## Verification

- [ ] Built the affected targets
- [x] Ran the relevant tests or static validation
- [ ] Updated docs if behavior or public APIs changed

Validation performed:

- Parsed an expression-backed sprite shader property with `ParticleScriptCompiler` and verified the generated `shader.tint` link.
- `ruff check python/Infernux/particle/script.py --select F821`
- `python3 -m py_compile python/Infernux/particle/script.py`
- `git diff --check`

## Notes for reviewers

- No test files are included in this PR.
- No public API or documentation changes are required.
