### PR TITLE
fix: import Debug for suppressed error paths

### DIFF
--- a/python/Infernux/core/material.py
+++ b/python/Infernux/core/material.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import time
 from typing import Optional, Tuple
 
+from Infernux.debug import Debug
 from Infernux.lib import InxMaterial
 
 _EMBEDDED_MODEL_MAT_TOKEN = "::submat:"

--- a/python/Infernux/engine/ui/inspector_components.py
+++ b/python/Infernux/engine/ui/inspector_components.py
@@ -13,6 +13,7 @@ import time as _time
 from dataclasses import replace
 from types import SimpleNamespace
 from Infernux.components.component import InxComponent
+from Infernux.debug import Debug
 from Infernux.lib import InxGUIContext
 from Infernux.engine.i18n import t
 from . import inspector_support as _inspector_support

--- a/python/Infernux/renderstack/render_stack.py
+++ b/python/Infernux/renderstack/render_stack.py
@@ -36,6 +36,7 @@ from typing import Dict, Optional, TYPE_CHECKING
 from Infernux.components.component import InxComponent
 from Infernux.components.fields import FieldType, list_field
 from Infernux.components.decorators import disallow_multiple, add_component_menu
+from Infernux.debug import Debug
 from Infernux.renderstack._pipeline_common import (
     COLOR_TEXTURE,
     ensure_standard_post_process_points,


### PR DESCRIPTION
## Summary

Several Python error handlers log suppressed exceptions through `Debug.log` without importing `Debug`. When those handlers run, they raise `NameError` and mask the original material, Inspector, or RenderStack error instead of preserving the intended fallback behavior.

## What changed

- Import `Debug` from the existing `Infernux.debug` module in the material wrapper.
- Import the same logger in Inspector component rendering and RenderStack lifecycle handling.

## Verification

- [ ] Built the affected targets
- [x] Ran the relevant tests or static validation
- [ ] Updated docs if behavior or public APIs changed

Validation performed:

- `ruff check python/Infernux/core/material.py python/Infernux/engine/ui/inspector_components.py python/Infernux/renderstack/render_stack.py --select F821`
- `python3 -m py_compile` for all three modified modules.
- Exercised the material registry failure path and verified it returns `None` after logging the original `RuntimeError`.
- `git diff --check`

## Notes for reviewers

- All affected call sites came from the same suppressed-exception logging pattern.
- No test files are included in this PR.
- No public API or documentation changes are required.
